### PR TITLE
feat: organize additional ball dataset source

### DIFF
--- a/context/ball_extra_dataset.md
+++ b/context/ball_extra_dataset.md
@@ -1,0 +1,37 @@
+# Additional dataset for ball detection
+
+## Source
+Roboflow dataset: PlayersDetection 2
+
+## Purpose
+This dataset is used as an additional source focused on improving the hardest class in the project, especially ball detection.
+
+## Local raw path
+`data/raw/ball_extra/playersdetection_v2_coco`
+
+## Download format
+COCO
+
+## Current structure
+The dataset is stored locally with three splits:
+- `train/`
+- `valid/`
+- `test/`
+
+Each split contains images and COCO annotations in JSON format.
+
+## Validation
+The dataset structure is checked with:
+`scripts/inspect_extra_dataset.py`
+
+The inspection verifies:
+- split presence,
+- image counts,
+- annotation file presence,
+- annotation counts,
+- category list.
+
+## Notes
+This dataset is kept as a raw source for now.
+It is not yet converted to the common training format.
+Conversion will be handled in the next data-format issue.

--- a/scripts/inspect_extra_dataset.py
+++ b/scripts/inspect_extra_dataset.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+
+
+def find_images(split_dir: Path) -> list[Path]:
+    images = []
+    for p in split_dir.rglob("*"):
+        if p.is_file() and p.suffix.lower() in IMAGE_EXTS:
+            images.append(p)
+    return images
+
+
+def find_annotation_json(split_dir: Path) -> Path | None:
+    json_files = list(split_dir.glob("*.json"))
+    if not json_files:
+        return None
+
+    preferred = [p for p in json_files if "coco" in p.name.lower() or "annotation" in p.name.lower()]
+    if preferred:
+        return preferred[0]
+    return json_files[0]
+
+
+def summarize_split(split_dir: Path) -> dict:
+    images = find_images(split_dir)
+    ann_path = find_annotation_json(split_dir)
+
+    summary = {
+        "split": split_dir.name,
+        "split_path": str(split_dir),
+        "image_count": len(images),
+        "annotation_file": str(ann_path) if ann_path else None,
+        "annotation_count": 0,
+        "category_count": 0,
+        "categories": [],
+    }
+
+    if ann_path and ann_path.exists():
+        with ann_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        categories = data.get("categories", [])
+        annotations = data.get("annotations", [])
+
+        summary["annotation_count"] = len(annotations)
+        summary["category_count"] = len(categories)
+        summary["categories"] = [c.get("name", f"id_{c.get('id')}") for c in categories]
+
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inspect additional Roboflow COCO dataset.")
+    parser.add_argument(
+        "--dataset-root",
+        required=True,
+        help="Path to dataset root, e.g. data/raw/ball_extra/playersdetection_v2_coco",
+    )
+    args = parser.parse_args()
+
+    dataset_root = Path(args.dataset_root)
+    if not dataset_root.exists():
+        raise FileNotFoundError(f"Dataset root does not exist: {dataset_root}")
+
+    splits = ["train", "valid", "test"]
+    result = {
+        "dataset_root": str(dataset_root),
+        "splits": {},
+    }
+
+    for split in splits:
+        split_dir = dataset_root / split
+        if split_dir.exists():
+            result["splits"][split] = summarize_split(split_dir)
+        else:
+            result["splits"][split] = {
+                "split": split,
+                "missing": True,
+            }
+
+    output_path = dataset_root / "dataset_summary.json"
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2, ensure_ascii=False)
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    print(f"\nSaved summary to: {output_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR adds the initial setup for the additional Roboflow dataset used for ball detection.

Included:
- dataset structure defined locally under `data/raw/ball_extra/playersdetection_v2_coco`
- dataset inspection script: `scripts/inspect_extra_dataset.py`
- repository documentation: `context/ball_extra_dataset.md`

Notes:
- raw data is kept locally and is not committed
- conversion to the common format will be handled in the next issue