### PR TITLE
feat: add soccernet dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,76 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
+## SoccerNet raw data (COCO flow)
+
+Download should be done via the SoccerNet Python library.
+
+1. Set SoccerNet password in `.env`:
+
+```bash
+SOCCERNET_PASSWORD=CHANGEME
+```
+
+2. For player and ball recognition, use tracking task data (not action spotting labels):
+
+```bash
+python scripts/download_soccernet_dataset.py --mode task --task tracking-2023 --splits train --no-extract
+```
+
+To download all available splits for a task (can be very large on disk):
+
+```bash
+python scripts/download_soccernet_dataset.py --mode task --task tracking-2023 --splits train test challenge --source HuggingFace
+```
+
+Local lightweight smoke test (1-2 matches) in `games` mode below is only for quick checks and can use action-spotting labels:
+
+```bash
+python scripts/download_soccernet_dataset.py --mode games --splits train --max-games 2 --files 1_224p.mkv 2_224p.mkv Labels-v2.json
+```
+
+To download all available matches from selected splits in `games` mode, skip `--max-games` (or set it to `0`):
+
+```bash
+python scripts/download_soccernet_dataset.py --mode games --splits train test --files 1_224p.mkv 2_224p.mkv 1_player_boundingbox_maskrcnn.json 2_player_boundingbox_maskrcnn.json
+```
+
+3. Inspect extracted data and validate COCO keys (`images`, `annotations`, `categories`):
+
+```bash
+python scripts/inspect_soccernet_dataset.py --dataset-root data/raw/soccernet/soccernet_tracking_2023_coco
+```
+
+This stage keeps data as raw source only. Conversion to shared training format is handled in a later issue.
+
+### Download parameters
+
+Main mode and task settings:
+- `--mode {task,games}`: `task` downloads task packages; `games` downloads selected files per match.
+- `--task`: SoccerNet task name for `task` mode (default: `tracking-2023`).
+- `--splits`: splits to download (`train`, `valid`, `test`, `challenge` depending on task availability).
+- `--task-version`: optional task version (example: `224p`).
+- `--source`: source backend passed to SoccerNet downloader (default: `HuggingFace`).
+
+Games mode settings:
+- `--games-task`: game list provider used by SoccerNet `getListGames` (default: `spotting`).
+- `--files`: files to download for each selected match.
+- `--max-games`: max matches per split; `0` means no limit (all available).
+- `--randomized`: randomize match order before selecting first `--max-games`.
+
+Output and auth settings:
+- `--output-root`: local root for raw downloads (default: `data/raw/soccernet`).
+- `--extract-root`: extraction target for zip archives in `task` mode.
+- `--password`: override password from CLI.
+- `.env`: if `--password` is not provided, the script reads `SOCCERNET_PASSWORD` / `SOCCERNET_DATA_PASSWORD`.
+- `--no-extract`: keep downloaded archives without extraction in `task` mode.
+
+For the full up-to-date list run:
+
+```bash
+python scripts/download_soccernet_dataset.py --help
+```
+
 ## Quick start (Stage 1 mock flow)
 
 This repository now contains a simple mock integration flow for two model names:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas>=2.2
 opencv-python>=4.10
 streamlit>=1.35
 torch>=2.2
+SoccerNet>=0.1.62

--- a/scripts/download_soccernet_dataset.py
+++ b/scripts/download_soccernet_dataset.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib
+import logging
+import os
+from pathlib import Path
+import random
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT_ROOT = Path("data/raw/soccernet")
+DEFAULT_EXTRACT_ROOT = Path("data/raw/soccernet/soccernet_tracking_2023_coco")
+ENV_PATH = ROOT / ".env"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
+logger = logging.getLogger("download_soccernet_dataset")
+
+
+def build_downloader(local_directory: str):
+    try:
+        module = importlib.import_module("SoccerNet.Downloader")
+        utils_module = importlib.import_module("SoccerNet.utils")
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            "Missing dependency 'SoccerNet'. Install requirements first: pip install -r requirements.txt"
+        ) from exc
+
+    return module.SoccerNetDownloader(LocalDirectory=local_directory), utils_module.getListGames
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download SoccerNet data using SoccerNet library.")
+    parser.add_argument("--mode", choices=["task", "games"], default="task", help="Download mode")
+    parser.add_argument("--task", default="tracking-2023", help="SoccerNet task name, e.g. tracking-2023")
+    parser.add_argument("--splits", nargs="+", default=["train", "test"], help="Task splits to download")
+    parser.add_argument(
+        "--task-version",
+        default=None,
+        help="Optional version passed to downloadDataTask, e.g. 224p",
+    )
+    parser.add_argument(
+        "--games-task",
+        default="spotting",
+        help="Task used by getListGames in games mode, e.g. spotting",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="+",
+        default=["1_224p.mkv", "2_224p.mkv", "Labels-v2.json"],
+        help="Files downloaded per game in games mode",
+    )
+    parser.add_argument("--max-games", type=int, default=0, help="Limit number of games per split in games mode")
+    parser.add_argument("--randomized", action="store_true", help="Randomize game order in games mode")
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT), help="Base local output directory")
+    parser.add_argument(
+        "--extract-root",
+        default=str(DEFAULT_EXTRACT_ROOT),
+        help="Where extracted zip contents should be placed",
+    )
+    parser.add_argument("--source", default="HuggingFace", help="Download source passed to SoccerNetDownloader")
+    parser.add_argument("--password", default=None, help="SoccerNet task password if required")
+    parser.add_argument("--no-extract", action="store_true", help="Skip zip extraction step")
+    return parser.parse_args()
+
+
+def resolve_path(path_arg: str) -> Path:
+    candidate = Path(path_arg)
+    if candidate.is_absolute():
+        return candidate
+    return (ROOT / candidate).resolve()
+
+
+def load_dotenv(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+
+    parsed: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        parsed[key.strip()] = value.strip().strip("\"'")
+    return parsed
+
+
+def resolve_password(cli_password: str | None, dotenv_values: dict[str, str]) -> tuple[str | None, str]:
+    if cli_password:
+        return cli_password, "cli"
+
+    for key in ("SOCCERNET_PASSWORD", "SOCCERNET_DATA_PASSWORD"):
+        value = dotenv_values.get(key)
+        if value and "CHANGEME" not in value and "YOUR_" not in value:
+            return value, f".env:{key}"
+
+    for key in ("SOCCERNET_PASSWORD", "SOCCERNET_DATA_PASSWORD"):
+        value = os.getenv(key)
+        if value and "CHANGEME" not in value and "YOUR_" not in value:
+            return value, f"env:{key}"
+    return None, "default"
+
+
+def find_zip_archives(task_root: Path) -> list[Path]:
+    if not task_root.exists():
+        return []
+    return sorted([p for p in task_root.rglob("*.zip") if p.is_file()])
+
+
+def split_from_name(archive_name: str) -> str:
+    lowered = archive_name.lower()
+    if "train" in lowered:
+        return "train"
+    if "valid" in lowered or "val" in lowered:
+        return "valid"
+    if "test" in lowered:
+        return "test"
+    if "challenge" in lowered:
+        return "challenge"
+    return "other"
+
+
+def extract_archives(archives: list[Path], extract_root: Path) -> list[Path]:
+    extracted_to: list[Path] = []
+    extract_root.mkdir(parents=True, exist_ok=True)
+
+    for archive in archives:
+        destination = extract_root / split_from_name(archive.stem)
+        destination.mkdir(parents=True, exist_ok=True)
+        logger.info("extracting %s -> %s", archive, destination)
+        with zipfile.ZipFile(archive, "r") as zip_handle:
+            zip_handle.extractall(destination)
+        extracted_to.append(destination)
+
+    return extracted_to
+
+
+def select_games(get_list_games, split: str, games_task: str, max_games: int, randomized: bool) -> list[str]:
+    game_list = list(get_list_games(split=split, task=games_task))
+    if randomized:
+        random.shuffle(game_list)
+    if max_games > 0:
+        return game_list[:max_games]
+    return game_list
+
+
+def warn_on_action_spotting_inputs(mode: str, games_task: str, files: list[str]) -> None:
+    if mode != "games":
+        return
+
+    normalized = {f.lower() for f in files}
+    has_action_labels = "labels-v2.json" in normalized
+    if has_action_labels:
+        logger.warning(
+            "Labels-v2.json are action spotting events, not player/ball detection annotations."
+        )
+    if games_task == "spotting" and has_action_labels:
+        logger.warning(
+            "games_task=spotting targets action spotting data. For player/ball use mode=task with task=tracking-2023."
+        )
+
+
+def main() -> int:
+    args = parse_args()
+
+    output_root = resolve_path(args.output_root)
+    extract_root = resolve_path(args.extract_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    dotenv_values = load_dotenv(ENV_PATH)
+    password, password_source = resolve_password(args.password, dotenv_values)
+    effective_password = password or "SoccerNet"
+    logger.info("password source=%s", password_source)
+    warn_on_action_spotting_inputs(args.mode, args.games_task, args.files)
+
+    downloader, get_list_games = build_downloader(str(output_root))
+    downloader.password = effective_password
+
+    if args.mode == "task":
+        if args.max_games > 0:
+            logger.info("--max-games is ignored in task mode")
+
+        logger.info("downloading task=%s splits=%s to %s", args.task, args.splits, output_root)
+        downloader.downloadDataTask(
+            task=args.task,
+            split=args.splits,
+            password=effective_password,
+            source=args.source,
+            version=args.task_version,
+        )
+
+        task_root = output_root / args.task
+        archives = find_zip_archives(task_root)
+        logger.info("download completed, found %s zip archives in %s", len(archives), task_root)
+
+        if args.no_extract:
+            return 0
+
+        if not archives:
+            logger.warning("no zip archives found for extraction")
+            return 0
+
+        extracted_to = extract_archives(archives, extract_root)
+        logger.info("extraction completed into %s", extract_root)
+        logger.info("touched split folders: %s", ", ".join(sorted({str(p) for p in extracted_to})))
+        return 0
+
+    logger.info(
+        "downloading selected games (games_task=%s, splits=%s, max_games=%s)",
+        args.games_task,
+        args.splits,
+        args.max_games,
+    )
+    for split in args.splits:
+        games = select_games(get_list_games, split, args.games_task, args.max_games, args.randomized)
+        logger.info("split=%s selected_games=%s", split, len(games))
+        for game in games:
+            downloader.downloadGame(game=game, files=args.files, spl=split, verbose=True)
+
+    logger.info("games mode download completed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/inspect_soccernet_dataset.py
+++ b/scripts/inspect_soccernet_dataset.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+COCO_KEYS = {"images", "annotations", "categories"}
+
+
+def find_images(split_dir: Path) -> list[Path]:
+    return [p for p in split_dir.rglob("*") if p.is_file() and p.suffix.lower() in IMAGE_EXTS]
+
+
+def find_annotation_json(split_dir: Path) -> Path | None:
+    json_files = [p for p in split_dir.rglob("*.json") if p.is_file()]
+    if not json_files:
+        return None
+
+    preferred = [
+        p
+        for p in json_files
+        if any(token in p.name.lower() for token in ("coco", "annotation", "annotations", "instances"))
+    ]
+    return preferred[0] if preferred else json_files[0]
+
+
+def summarize_split(split_dir: Path, split_name: str) -> dict:
+    images = find_images(split_dir)
+    ann_path = find_annotation_json(split_dir)
+
+    summary = {
+        "split": split_name,
+        "split_path": str(split_dir),
+        "image_count": len(images),
+        "annotation_file": str(ann_path) if ann_path else None,
+        "annotation_count": 0,
+        "category_count": 0,
+        "categories": [],
+        "is_coco": False,
+        "missing_coco_keys": sorted(list(COCO_KEYS)),
+    }
+
+    if ann_path and ann_path.exists():
+        with ann_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        categories = data.get("categories", [])
+        annotations = data.get("annotations", [])
+        summary["annotation_count"] = len(annotations)
+        summary["category_count"] = len(categories)
+        summary["categories"] = [c.get("name", f"id_{c.get('id')}") for c in categories]
+
+        present = {k for k in COCO_KEYS if k in data}
+        summary["is_coco"] = len(present) == len(COCO_KEYS)
+        summary["missing_coco_keys"] = sorted(list(COCO_KEYS - present))
+
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inspect SoccerNet dataset and verify COCO-like structure.")
+    parser.add_argument(
+        "--dataset-root",
+        required=True,
+        help="Path to extracted dataset root, e.g. data/raw/soccernet/soccernet_tracking_2023_coco",
+    )
+    parser.add_argument("--splits", nargs="+", default=["train", "valid", "test"])
+    args = parser.parse_args()
+
+    dataset_root = Path(args.dataset_root)
+    if not dataset_root.exists():
+        raise FileNotFoundError(f"Dataset root does not exist: {dataset_root}")
+
+    result = {
+        "dataset_root": str(dataset_root),
+        "splits": {},
+    }
+
+    for split in args.splits:
+        split_dir = dataset_root / split
+        if split_dir.exists():
+            result["splits"][split] = summarize_split(split_dir, split)
+        else:
+            result["splits"][split] = {
+                "split": split,
+                "missing": True,
+            }
+
+    output_path = dataset_root / "dataset_summary.json"
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2, ensure_ascii=False)
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    print(f"\nSaved summary to: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This pull request introduces a new, robust workflow for downloading and inspecting raw SoccerNet data in COCO format. It adds two new scripts: one for flexible, parameterized downloading of SoccerNet datasets and another for validating the extracted data structure. The `README.md` is also updated with comprehensive, step-by-step instructions for using these scripts, including environment setup and parameter explanations.

**Major changes:**

**1. New download and inspection scripts for SoccerNet data:**
- Added `scripts/download_soccernet_dataset.py`, a configurable script for downloading SoccerNet datasets in either "task" or "games" mode, supporting split selection, file selection, password management, extraction, and backend source selection.
- Added `scripts/inspect_soccernet_dataset.py`, a script to verify the structure of extracted SoccerNet datasets, count images and annotations, and check for COCO compliance.

**2. Documentation updates and usage guidance:**
- Expanded the `README.md` with a new section detailing how to use the SoccerNet Python library for dataset download, including environment variable setup, download modes, parameter descriptions, and example commands for both quick tests and full dataset acquisition.

**3. Improved dataset validation and user experience:**
- The inspection script outputs a JSON summary of the dataset, highlighting missing files or COCO keys, and saves the summary to disk for further review.
- The download script provides warnings when users attempt to download action spotting labels inappropriately and logs all steps for transparency.