### PR TITLE
feat: implement variant assembly and transformed dataset variants

### DIFF
--- a/scripts/build_ready_variants.py
+++ b/scripts/build_ready_variants.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from murawa.data.variant_assembly import (  # noqa: E402
+    SUPPORTED_VARIANTS,
+    VariantAssemblyConfig,
+    assemble_variant,
+    describe_variant,
+)
+
+LOGGER = logging.getLogger("build-ready-variants")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build experiment-ready dataset variants in data/ready."
+    )
+    parser.add_argument(
+        "--variant",
+        choices=SUPPORTED_VARIANTS,
+        default=None,
+        help="Build only one variant. Default: build all supported variants.",
+    )
+    parser.add_argument(
+        "--selected-root",
+        default=str(ROOT / "data" / "selected"),
+    )
+    parser.add_argument(
+        "--final-root",
+        default=str(ROOT / "data" / "ready"),
+    )
+    parser.add_argument(
+        "--frame-step",
+        type=int,
+        default=30,
+        help="Reference frame_step passed to bootstrap source variants.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing output variants.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
+
+    variants_to_build = [args.variant] if args.variant else list(SUPPORTED_VARIANTS)
+    LOGGER.info("Preparing variants: %s", ", ".join(variants_to_build))
+
+    for variant_name in variants_to_build:
+        variant_dir = assemble_variant(
+            VariantAssemblyConfig(
+                selected_root=Path(args.selected_root),
+                final_root=Path(args.final_root),
+                variant_name=variant_name,
+                frame_step=args.frame_step,
+                force=args.force,
+            )
+        )
+        LOGGER.info("Variant ready: %s", variant_dir)
+        LOGGER.info("Description: %s", json.dumps(describe_variant(variant_dir), ensure_ascii=False))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/murawa/data/variant_assembly.py
+++ b/src/murawa/data/variant_assembly.py
@@ -1,7 +1,32 @@
 from __future__ import annotations
 
+import json
+import shutil
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+
+import cv2
+
+from murawa.data.bootstrap_variant import (
+    BootstrapConfig,
+    SPLITS,
+    SUPPORTED_VARIANTS as BOOTSTRAP_VARIANTS,
+    build_bootstrap_variant,
+    describe_variant_composition,
+)
+from murawa.data.variant_image_transforms import (
+    TRANSFORM_PIPELINE_NAME,
+    TRANSFORM_PIPELINE_OPS,
+    apply_lightweight_training_transform,
+)
+
+COCO_REQUIRED_KEYS = {"images", "annotations", "categories"}
+SUPPORTED_VARIANTS = (
+    *BOOTSTRAP_VARIANTS,
+    "extended-transformed",
+    "extended-only-train-transformed",
+)
 
 
 @dataclass(frozen=True)
@@ -11,19 +36,415 @@ class VariantAssemblyConfig:
     variant_name: str
     include_ball_extra: bool = False
     enable_transforms: bool = False
+    frame_step: int = 30
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class VariantSpec:
+    variant_name: str
+    source_variant: str
+    transforms_enabled: bool = False
 
 
 def assemble_variant(config: VariantAssemblyConfig) -> Path:
-    """Issue #09: assemble named experiment-ready variant in data/ready."""
-    raise NotImplementedError(
-        "TODO(Issue #09): assemble clearly named variants (base, ball-extended, transformed/preprocessed) "
-        "in data/ready and ensure each variant is directly consumable by training scripts."
+    """Build one named variant in data/ready and write concise metadata."""
+    spec = _resolve_variant_spec(config.variant_name)
+    project_root = _resolve_project_root(config.final_root)
+
+    if spec.transforms_enabled:
+        source_variant_dir = _ensure_source_variant(
+            project_root=project_root,
+            final_root=config.final_root,
+            source_variant=spec.source_variant,
+            frame_step=config.frame_step,
+            force=config.force,
+        )
+
+        target_variant_dir = config.final_root / spec.variant_name
+        if target_variant_dir.exists():
+            if not config.force:
+                _validate_variant_dir(target_variant_dir)
+                _write_variant_metadata(
+                    variant_dir=target_variant_dir,
+                    config=config,
+                    spec=spec,
+                    project_root=project_root,
+                    transform_summary=None,
+                )
+                return target_variant_dir
+            shutil.rmtree(target_variant_dir)
+
+        shutil.copytree(source_variant_dir, target_variant_dir)
+
+        copied_bootstrap_summary = target_variant_dir / "bootstrap_summary.json"
+        if copied_bootstrap_summary.exists():
+            copied_bootstrap_summary.unlink()
+
+        transform_summary = _augment_train_split_with_transformed_copies(target_variant_dir / "train")
+        _validate_variant_dir(target_variant_dir)
+        _write_variant_metadata(
+            variant_dir=target_variant_dir,
+            config=config,
+            spec=spec,
+            project_root=project_root,
+            transform_summary=transform_summary,
+        )
+        return target_variant_dir
+
+    target_variant_dir = config.final_root / spec.variant_name
+    if not target_variant_dir.exists() or config.force:
+        build_bootstrap_variant(
+            project_root=project_root,
+            config=BootstrapConfig(
+                output_variant=spec.variant_name,
+                frame_step=config.frame_step,
+                force=config.force,
+            ),
+        )
+
+    _validate_variant_dir(target_variant_dir)
+    _write_variant_metadata(
+        variant_dir=target_variant_dir,
+        config=config,
+        spec=spec,
+        project_root=project_root,
+        transform_summary=None,
     )
+    return target_variant_dir
 
 
 def describe_variant(variant_dir: Path) -> dict[str, str]:
-    """Issue #09: produce concise metadata describing what differentiates this variant."""
-    raise NotImplementedError(
-        "TODO(Issue #09): generate short variant notes (source composition + preprocessing flags) "
-        "so run-to-variant traceability is explicit."
+    """Produce concise metadata explaining what differentiates this variant."""
+    variant_dir = Path(variant_dir)
+    spec = _resolve_variant_spec(variant_dir.name)
+    split_stats = _read_split_stats(variant_dir)
+
+    composition = describe_variant_composition(spec.source_variant)
+    train_sources = list(composition["train"])
+    if spec.transforms_enabled:
+        train_sources.append("transformed-copies")
+
+    return {
+        "variant_name": spec.variant_name,
+        "derived_from_variant": spec.source_variant,
+        "train_sources": ", ".join(train_sources),
+        "valid_sources": ", ".join(composition["valid"]),
+        "test_sources": ", ".join(composition["test"]),
+        "transforms_enabled": str(spec.transforms_enabled).lower(),
+        "transform_scope": "train only" if spec.transforms_enabled else "none",
+        "transform_pipeline": TRANSFORM_PIPELINE_NAME if spec.transforms_enabled else "none",
+        "transform_ops": " | ".join(TRANSFORM_PIPELINE_OPS) if spec.transforms_enabled else "none",
+        "train_images": str(split_stats["train"]["images"]),
+        "train_annotations": str(split_stats["train"]["annotations"]),
+        "valid_images": str(split_stats["valid"]["images"]),
+        "valid_annotations": str(split_stats["valid"]["annotations"]),
+        "test_images": str(split_stats["test"]["images"]),
+        "test_annotations": str(split_stats["test"]["annotations"]),
+    }
+
+
+def _resolve_variant_spec(variant_name: str) -> VariantSpec:
+    if variant_name in BOOTSTRAP_VARIANTS:
+        return VariantSpec(variant_name=variant_name, source_variant=variant_name, transforms_enabled=False)
+
+    if variant_name == "extended-transformed":
+        return VariantSpec(
+            variant_name=variant_name,
+            source_variant="extended",
+            transforms_enabled=True,
+        )
+
+    if variant_name == "extended-only-train-transformed":
+        return VariantSpec(
+            variant_name=variant_name,
+            source_variant="extended-only-train",
+            transforms_enabled=True,
+        )
+
+    raise ValueError(
+        f"Unsupported variant '{variant_name}'. "
+        f"Expected one of: {', '.join(SUPPORTED_VARIANTS)}"
     )
+
+
+def _resolve_project_root(final_root: Path) -> Path:
+    final_root = Path(final_root).resolve()
+    return final_root.parents[1]
+
+def _to_project_relative_path(path: Path, project_root: Path) -> str:
+    path = Path(path).resolve()
+    project_root = Path(project_root).resolve()
+    try:
+        return str(path.relative_to(project_root)).replace("\\", "/")
+    except ValueError:
+        return str(path)
+
+def _ensure_source_variant(
+    *,
+    project_root: Path,
+    final_root: Path,
+    source_variant: str,
+    frame_step: int,
+    force: bool,
+) -> Path:
+    source_variant_dir = Path(final_root) / source_variant
+
+    # Do not rebuild an already prepared source variant here.
+    # During full runs, base variants are built first and transformed variants
+    # should reuse them instead of wiping their metadata.
+    if source_variant_dir.exists():
+        return source_variant_dir
+
+    build_bootstrap_variant(
+        project_root=project_root,
+        config=BootstrapConfig(
+            output_variant=source_variant,
+            frame_step=frame_step,
+            force=force,
+        ),
+    )
+    return source_variant_dir
+
+
+def _augment_train_split_with_transformed_copies(train_split_dir: Path) -> dict[str, object]:
+    annotation_path = train_split_dir / "_annotations.coco.json"
+    payload = _load_coco(annotation_path)
+
+    images = payload["images"]
+    annotations = payload["annotations"]
+    categories = payload["categories"]
+    info = payload.get("info", {})
+
+    images_dir = train_split_dir / "images"
+    annotations_by_image: dict[int, list[dict]] = defaultdict(list)
+    for ann in annotations:
+        image_id = ann.get("image_id")
+        if isinstance(image_id, int):
+            annotations_by_image[image_id].append(ann)
+
+    original_images = list(images)
+    next_image_id = max((img["id"] for img in images), default=0) + 1
+    next_annotation_id = max((ann["id"] for ann in annotations), default=0) + 1
+
+    added_images = 0
+    added_annotations = 0
+    skipped_images = 0
+    preview_files: list[str] = []
+
+    for image_entry in original_images:
+        file_name = image_entry.get("file_name")
+        image_id = image_entry.get("id")
+        if not isinstance(file_name, str) or not isinstance(image_id, int):
+            skipped_images += 1
+            continue
+
+        source_path = train_split_dir / file_name
+        image = cv2.imread(str(source_path), cv2.IMREAD_COLOR)
+        if image is None:
+            skipped_images += 1
+            continue
+
+        transformed_image, transform_metadata = apply_lightweight_training_transform(image=image, key=file_name)
+
+        base_name = Path(file_name).name
+        stem = Path(base_name).stem
+        suffix = Path(base_name).suffix
+        transformed_base_name = f"{stem}__tf{suffix}"
+        transformed_rel_path = f"images/{transformed_base_name}"
+        transformed_abs_path = images_dir / transformed_base_name
+
+        cv2.imwrite(str(transformed_abs_path), transformed_image)
+        height, width = transformed_image.shape[:2]
+
+        images.append(
+            {
+                "id": next_image_id,
+                "file_name": transformed_rel_path,
+                "width": width,
+                "height": height,
+            }
+        )
+
+        for ann in annotations_by_image.get(image_id, []):
+            duplicated = dict(ann)
+            duplicated["id"] = next_annotation_id
+            duplicated["image_id"] = next_image_id
+            annotations.append(duplicated)
+            next_annotation_id += 1
+            added_annotations += 1
+
+        if len(preview_files) < 5:
+            preview_files.append(f"{transformed_base_name} [{transform_metadata.pipeline}]")
+
+        next_image_id += 1
+        added_images += 1
+
+    payload["info"] = {
+        **info,
+        "derived_train_transforms": {
+            "pipeline": TRANSFORM_PIPELINE_NAME,
+            "ops": list(TRANSFORM_PIPELINE_OPS),
+            "scope": "train only",
+            "added_images": added_images,
+            "added_annotations": added_annotations,
+        },
+    }
+    annotation_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    return {
+        "pipeline": TRANSFORM_PIPELINE_NAME,
+        "ops": list(TRANSFORM_PIPELINE_OPS),
+        "scope": "train only",
+        "added_images": added_images,
+        "added_annotations": added_annotations,
+        "skipped_images": skipped_images,
+        "preview_files": preview_files,
+    }
+
+
+def _write_variant_metadata(
+    *,
+    variant_dir: Path,
+    config: VariantAssemblyConfig,
+    spec: VariantSpec,
+    project_root: Path,
+    transform_summary: dict[str, object] | None,
+) -> None:
+    description = describe_variant(variant_dir)
+    description["selected_root_reference"] = _to_project_relative_path(config.selected_root, project_root)
+    description["final_root"] = _to_project_relative_path(config.final_root, project_root)
+    description["bootstrap_source_of_truth"] = "true"
+    description["frame_step_reference"] = str(config.frame_step)
+
+    if transform_summary is not None:
+        description["transformed_images_added_train"] = str(transform_summary["added_images"])
+        description["transformed_annotations_added_train"] = str(transform_summary["added_annotations"])
+
+    (variant_dir / "variant_description.json").write_text(
+        json.dumps(description, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    summary = _build_variant_summary(
+        variant_dir=variant_dir,
+        spec=spec,
+        config=config,
+        project_root=project_root,
+        transform_summary=transform_summary,
+    )
+    (variant_dir / "variant_summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _build_variant_summary(
+    *,
+    variant_dir: Path,
+    spec: VariantSpec,
+    config: VariantAssemblyConfig,
+    project_root: Path,
+    transform_summary: dict[str, object] | None,
+) -> dict[str, object]:
+    split_stats = _read_split_stats(variant_dir)
+    composition = describe_variant_composition(spec.source_variant)
+
+    train_sources = list(composition["train"])
+    if spec.transforms_enabled:
+        train_sources.append("transformed-copies")
+
+    return {
+        "variant": spec.variant_name,
+        "derived_from_variant": spec.source_variant,
+        "bootstrap_source_of_truth": True,
+        "selected_root_reference": _to_project_relative_path(config.selected_root, project_root),
+        "final_root": _to_project_relative_path(config.final_root, project_root),
+        "frame_step_reference": config.frame_step,
+        "transforms": {
+            "enabled": spec.transforms_enabled,
+            "scope": "train only" if spec.transforms_enabled else "none",
+            "pipeline": TRANSFORM_PIPELINE_NAME if spec.transforms_enabled else "none",
+            "ops": list(TRANSFORM_PIPELINE_OPS) if spec.transforms_enabled else [],
+            "summary": transform_summary or {},
+        },
+        "splits": {
+            "train": {
+                "images": split_stats["train"]["images"],
+                "annotations": split_stats["train"]["annotations"],
+                "sources": train_sources,
+            },
+            "valid": {
+                "images": split_stats["valid"]["images"],
+                "annotations": split_stats["valid"]["annotations"],
+                "sources": list(composition["valid"]),
+            },
+            "test": {
+                "images": split_stats["test"]["images"],
+                "annotations": split_stats["test"]["annotations"],
+                "sources": list(composition["test"]),
+            },
+        },
+        "notes": [
+            "Split composition follows bootstrap_variant.py as the source of truth.",
+            "Transformed variants add lightweight transformed copies only to the train split.",
+            "Validation and test remain untransformed for cleaner comparison of model results.",
+        ],
+    }
+
+
+def _read_split_stats(variant_dir: Path) -> dict[str, dict[str, int]]:
+    stats: dict[str, dict[str, int]] = {}
+    for split in SPLITS:
+        annotation_path = variant_dir / split / "_annotations.coco.json"
+        payload = _load_coco(annotation_path)
+        stats[split] = {
+            "images": len(payload["images"]),
+            "annotations": len(payload["annotations"]),
+        }
+    return stats
+
+
+def _validate_variant_dir(variant_dir: Path) -> None:
+    if not variant_dir.exists():
+        raise FileNotFoundError(f"Variant directory does not exist: {variant_dir}")
+
+    for split in SPLITS:
+        split_dir = variant_dir / split
+        if not split_dir.is_dir():
+            raise FileNotFoundError(f"Missing split directory: {split_dir}")
+
+        annotation_path = split_dir / "_annotations.coco.json"
+        payload = _load_coco(annotation_path)
+
+        for image_entry in payload["images"]:
+            file_name = image_entry.get("file_name")
+            if not isinstance(file_name, str) or not file_name.strip():
+                raise ValueError(f"Invalid `file_name` entry in: {annotation_path}")
+
+            image_path = split_dir / file_name
+            if not image_path.exists():
+                raise FileNotFoundError(
+                    f"Broken image path in variant '{variant_dir.name}', split '{split}': {file_name}"
+                )
+
+
+def _load_coco(annotation_path: Path) -> dict:
+    if not annotation_path.exists():
+        raise FileNotFoundError(f"Missing COCO annotation file: {annotation_path}")
+
+    payload = json.loads(annotation_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not COCO_REQUIRED_KEYS.issubset(payload):
+        raise ValueError(
+            f"Invalid COCO payload in: {annotation_path}. "
+            f"Required keys: {sorted(COCO_REQUIRED_KEYS)}"
+        )
+    return payload
+
+
+__all__ = [
+    "SUPPORTED_VARIANTS",
+    "VariantAssemblyConfig",
+    "assemble_variant",
+    "describe_variant",
+]

--- a/src/murawa/data/variant_image_transforms.py
+++ b/src/murawa/data/variant_image_transforms.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+
+TRANSFORM_PIPELINE_NAME = "lightweight_color_scale_noise"
+TRANSFORM_PIPELINE_OPS = (
+    "light brightness/contrast/saturation shift",
+    "downscale-upscale resolution simulation",
+    "gaussian noise",
+)
+
+
+@dataclass(frozen=True)
+class TransformMetadata:
+    pipeline: str
+    brightness_beta: int
+    contrast_alpha: float
+    saturation_scale: float
+    downscale_factor: float
+    gaussian_sigma: float
+
+
+def apply_lightweight_training_transform(image: np.ndarray, key: str) -> tuple[np.ndarray, TransformMetadata]:
+    digest = hashlib.sha256(key.encode("utf-8")).digest()
+
+    brightness_beta = _pick_int(digest[0:2], low=-10, high=10)
+    contrast_alpha = 1.0 + (_pick_int(digest[2:4], low=-8, high=8) / 100.0)
+    saturation_scale = 1.0 + (_pick_int(digest[4:6], low=-10, high=10) / 100.0)
+    downscale_factor = 0.75 + ((int.from_bytes(digest[6:8], "big") % 16) / 100.0)
+    gaussian_sigma = 4.0 + float(int.from_bytes(digest[8:10], "big") % 5)
+
+    transformed = _apply_brightness_contrast(image, alpha=contrast_alpha, beta=brightness_beta)
+    transformed = _apply_saturation_shift(transformed, saturation_scale=saturation_scale)
+    transformed = _apply_downscale_upscale(transformed, factor=downscale_factor)
+    transformed = _apply_gaussian_noise(transformed, sigma=gaussian_sigma, seed=int.from_bytes(digest[10:18], "big"))
+
+    metadata = TransformMetadata(
+        pipeline=TRANSFORM_PIPELINE_NAME,
+        brightness_beta=brightness_beta,
+        contrast_alpha=contrast_alpha,
+        saturation_scale=saturation_scale,
+        downscale_factor=downscale_factor,
+        gaussian_sigma=gaussian_sigma,
+    )
+    return transformed, metadata
+
+
+def _pick_int(raw: bytes, *, low: int, high: int) -> int:
+    span = high - low + 1
+    return low + (int.from_bytes(raw, "big") % span)
+
+
+def _apply_brightness_contrast(image: np.ndarray, *, alpha: float, beta: int) -> np.ndarray:
+    return cv2.convertScaleAbs(image, alpha=alpha, beta=beta)
+
+
+def _apply_saturation_shift(image: np.ndarray, *, saturation_scale: float) -> np.ndarray:
+    hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV).astype(np.float32)
+    hsv[..., 1] = np.clip(hsv[..., 1] * saturation_scale, 0, 255)
+    shifted = cv2.cvtColor(hsv.astype(np.uint8), cv2.COLOR_HSV2BGR)
+    return shifted
+
+
+def _apply_downscale_upscale(image: np.ndarray, *, factor: float) -> np.ndarray:
+    height, width = image.shape[:2]
+    small_width = max(1, int(round(width * factor)))
+    small_height = max(1, int(round(height * factor)))
+
+    reduced = cv2.resize(image, (small_width, small_height), interpolation=cv2.INTER_AREA)
+    restored = cv2.resize(reduced, (width, height), interpolation=cv2.INTER_LINEAR)
+    return restored
+
+
+def _apply_gaussian_noise(image: np.ndarray, *, sigma: float, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    noise = rng.normal(0.0, sigma, image.shape).astype(np.float32)
+    noisy = image.astype(np.float32) + noise
+    return np.clip(noisy, 0, 255).astype(np.uint8)


### PR DESCRIPTION
## Cel PR

Ten PR domyka issue #9 poprzez dodanie jawnej warstwy assemblera wariantów danych oraz czytelnego opisu ich składu.

Celem tego etapu jest przygotowanie spójnego interfejsu do budowania gotowych zestawów w:

`data/ready/<variant>`

tak, aby później było jednoznacznie wiadomo:
- z jakiego wariantu pochodził dany model,
- jakie źródła danych były użyte per split,
- czy wariant zawierał dodatkowe transformacje obrazu.

Aktualny bootstrap pozostaje source of truth dla bazowych wariantów.

---

## Zakres tego PR

Ten PR obejmuje:

- implementację `assemble_variant(...)` w `src/murawa/data/variant_assembly.py`
- implementację `describe_variant(...)` w `src/murawa/data/variant_assembly.py`
- obsługę wariantów:
  - `base`
  - `extended`
  - `extended-only-train`
  - `extended-transformed`
  - `extended-only-train-transformed`
- dodanie lekkich, deterministycznych transformacji obrazu dla wariantów transformed
- dodanie skryptu uruchomieniowego `scripts/build_ready_variants.py`

---

## Założenia projektowe

### 1. Source of truth
Polityka splitów i skład bazowych wariantów nie są redefiniowane w tym PR.

Assembler opiera się na istniejącym bootstrapie jako source of truth dla:
- `base`
- `extended`
- `extended-only-train`

Nie ma tu re-splitu ani zmiany polityki miksu danych.

### 2. Warianty transformed
Dodatkowe warianty transformed są budowane jako warianty pochodne:
- `extended-transformed` jest pochodny od `extended`
- `extended-only-train-transformed` jest pochodny od `extended-only-train`

W obu przypadkach:
- valid/test pozostają bez zmian względem wariantu bazowego,
- train zostaje wzbogacony o przekształcone kopie obrazów.

Takie podejście pozwala zwiększyć trudność danych treningowych bez zaburzania porównania wyników na walidacji i teście.

### 3. Uwaga o `extended-only-train`
Assembler świadomie nie zmienia semantyki wariantu `extended-only-train`, tylko przejmuje aktualną logikę bootstrapu jako source of truth.

---

## Opis implementacji

### 1. `VariantAssemblyConfig`
Plik: `src/murawa/data/variant_assembly.py`

Konfiguracja wejściowa dla assemblera.  
Zawiera m.in. nazwę wariantu, ścieżki wejścia/wyjścia, referencję do `frame_step` oraz flagę `force`.

---

### 2. `assemble_variant(...)`
Plik: `src/murawa/data/variant_assembly.py`

To główna funkcja budująca pojedynczy wariant.

Jej odpowiedzialność:
- rozpoznanie, jaki wariant ma zostać zbudowany,
- dla bazowych wariantów: wykorzystanie istniejącego bootstrapu,
- dla wariantów transformed:
  - zbudowanie / użycie wariantu źródłowego,
  - skopiowanie go do nowego katalogu,
  - dodanie przekształconych kopii obrazów do train,
- walidacja końcowego outputu,
- zapis metadanych wariantu.

---

### 3. `describe_variant(...)`
Plik: `src/murawa/data/variant_assembly.py`

Ta funkcja generuje krótki, jednoznaczny opis wariantu.

Opis zawiera m.in.:
- nazwę wariantu,
- wariant bazowy, z którego pochodzi,
- źródła danych per split,
- informację, czy włączone są transformacje,
- liczbę obrazów i adnotacji w train/valid/test.

---

### 4. `variant_image_transforms.py`
Plik: `src/murawa/data/variant_image_transforms.py`

Ten moduł zawiera lekkie, deterministyczne transformacje obrazu używane w wariantach transformed.

Zakres transformacji:
- niewielka zmiana jasności / kontrastu / nasycenia,
- symulacja gorszej jakości obrazu przez downscale + upscale,
- lekki szum Gaussa.

Transformacje są celowo lekkie i nie zmieniają końcowego rozmiaru obrazu, dzięki czemu można zachować spójność adnotacji COCO bez dodatkowej geometrii bboxów.

---

### 5. `_augment_train_split_with_transformed_copies(...)`
Plik: `src/murawa/data/variant_assembly.py`

Ta funkcja odpowiada za wzbogacenie splitu `train` o dodatkowe przekształcone kopie obrazów.

Jej odpowiedzialność:
- odczyt COCO dla train,
- przejście po obrazach,
- zapis transformowanych kopii do `images/`,
- dodanie nowych wpisów do `images`,
- zduplikowanie adnotacji do nowych obrazów,
- zapis zaktualizowanego COCO.

---

### 6. `variant_description.json` i `variant_summary.json`
Assembler zapisuje dwa poziomy opisu:
- `variant_description.json` — krótki opis wariantu
- `variant_summary.json` — bardziej szczegółowe metadane, w tym liczby obrazów/adnotacji oraz źródła danych per split

Dzięki temu łatwiej odtworzyć, z jakiego wariantu pochodził model i jakie były różnice między wariantami.

---

### 7. `scripts/build_ready_variants.py`
Plik: `scripts/build_ready_variants.py`

To skrypt uruchomieniowy dla całego etapu.

Pozwala:
- zbudować jeden konkretny wariant,
- albo zbudować wszystkie warianty,
- z opcją `--force`, jeśli output ma zostać nadpisany.

---

## Jak uruchomić ten etap

Budowa jednego wariantu:
py scripts/build_ready_variants.py --variant extended-transformed --force

Budowa wszystkich wariantów:
py scripts/build_ready_variants.py --force

Uruchomiony został pełny build:
(py scripts/build_ready_variants.py --force)

### Wynik:
-powstają katalogi data/ready/<variant>
-zachowany zostaje format COCO + images
-zapisują się variant_description.json i variant_summary.json
-warianty transformed wzbogacają zbiór treningowy o dodatkowe przekształcone kopie obrazów

**Screen 1 - `data/ready`**  
<img width="756" height="332" alt="Zrzut ekranu 2026-04-23 202113" src="https://github.com/user-attachments/assets/db7af9d8-c55f-40d0-8c29-153f9d50686d" />
Screen 1 pokazuje katalog `data/ready` po zbudowaniu wariantów.
Widać, że assembler zapisuje gotowe zestawy danych w osobnych katalogach wariantów, co ułatwia późniejszy trening i porównanie wyników.

**Screen 2 - `data/ready/extended-transformed`**  
<img width="965" height="278" alt="Zrzut ekranu 2026-04-23 202215" src="https://github.com/user-attachments/assets/e447c219-3f90-4255-b892-197d4c789acc" />
Pokazuje strukturę wariantu `extended-transformed`.  
Widać splity `train`, `valid`, `test` oraz pliki metadanych wariantu (`variant_description.json`, `variant_summary.json`).

**Screen 3 - `variant_description.json`**  
<img width="1110" height="510" alt="Zrzut ekranu 2026-04-23 202237" src="https://github.com/user-attachments/assets/dfdfc526-4f35-4d11-8a8b-5084eb107fd0" />
Pokazuje krótki opis wariantu zapisany w `variant_description.json`.  
Ten plik pozwala szybko sprawdzić, z jakiego wariantu bazowego pochodzi dany zestaw, jakie są źródła danych per split oraz czy włączone są transformacje.

**Screen 4 - `variant_summary.json`**  
<img width="1382" height="851" alt="Zrzut ekranu 2026-04-23 202306" src="https://github.com/user-attachments/assets/8fbab392-29c2-4f68-be0f-3ccd454595c2" />
Pokazuje bardziej szczegółowe metadane wariantu w `variant_summary.json`.  
Widać tu m.in. źródła danych per split, zakres transformacji oraz liczbę obrazów i adnotacji.

**Screeny 5 - obraz oryginalny vs transformed**  
<img width="1280" height="720" alt="ballextra_train_2_pp_jpg rf 484409c41302d4bb5f32e9b96da4bc0e" src="https://github.com/user-attachments/assets/26455eee-6cd8-4a81-88c0-93624c18bb89" />
vs
<img width="1280" height="720" alt="ballextra_train_2_pp_jpg rf 484409c41302d4bb5f32e9b96da4bc0e__tf" src="https://github.com/user-attachments/assets/f6ffff24-8e2b-4569-a4ad-2338745233b3" />

**Screen 6 - porównanie `extended` vs `extended-transformed`**  
<img width="1899" height="134" alt="Zrzut ekranu 2026-04-23 202334" src="https://github.com/user-attachments/assets/1422aa11-7b64-45f6-a920-9a4243992e3f" />
Pokazuje różnicę między wariantem bazowym `extended` a `extended-transformed` na poziomie liczby obrazów i adnotacji.  
Wariant transformed wzbogaca zbiór treningowy o dodatkowe przekształcone kopie obrazów, zachowując spójny format COCO.

**Screen 7 - lista wygenerowanych plików transformowanych (__tf)**
<img width="1875" height="391" alt="Zrzut ekranu 2026-04-23 202354" src="https://github.com/user-attachments/assets/02456873-d4d1-40d6-9dcf-32313c2587c6" />
Ofc sufiks _tf oznacza przekształcone kopie obrazów.