### PR TITLE
tune transformed variant image effects

### DIFF
--- a/src/murawa/data/variant_image_transforms.py
+++ b/src/murawa/data/variant_image_transforms.py
@@ -6,11 +6,11 @@ from dataclasses import dataclass
 import cv2
 import numpy as np
 
-TRANSFORM_PIPELINE_NAME = "lightweight_color_scale_noise"
+TRANSFORM_PIPELINE_NAME = "boosted_color_scale_noise"
 TRANSFORM_PIPELINE_OPS = (
-    "light brightness/contrast/saturation shift",
-    "downscale-upscale resolution simulation",
-    "gaussian noise",
+    "stronger brightness/contrast/saturation shift",
+    "stronger downscale-upscale resolution degradation",
+    "stronger gaussian noise",
 )
 
 
@@ -25,18 +25,28 @@ class TransformMetadata:
 
 
 def apply_lightweight_training_transform(image: np.ndarray, key: str) -> tuple[np.ndarray, TransformMetadata]:
+    """Apply deterministic train-only visual degradation.
+
+    The transform is intentionally stronger than the first version, so that
+    the transformed images are visibly different during review and presentation,
+    while still preserving image geometry and COCO bbox coordinates.
+    """
     digest = hashlib.sha256(key.encode("utf-8")).digest()
 
-    brightness_beta = _pick_int(digest[0:2], low=-10, high=10)
-    contrast_alpha = 1.0 + (_pick_int(digest[2:4], low=-8, high=8) / 100.0)
-    saturation_scale = 1.0 + (_pick_int(digest[4:6], low=-10, high=10) / 100.0)
-    downscale_factor = 0.75 + ((int.from_bytes(digest[6:8], "big") % 16) / 100.0)
-    gaussian_sigma = 4.0 + float(int.from_bytes(digest[8:10], "big") % 5)
+    brightness_beta = _pick_int(digest[0:2], low=-35, high=35)
+    contrast_alpha = _pick_float(digest[2:4], low=0.70, high=1.40)
+    saturation_scale = _pick_float(digest[4:6], low=0.55, high=1.55)
+    downscale_factor = _pick_float(digest[6:8], low=0.45, high=0.65)
+    gaussian_sigma = _pick_float(digest[8:10], low=12.0, high=22.0)
 
     transformed = _apply_brightness_contrast(image, alpha=contrast_alpha, beta=brightness_beta)
     transformed = _apply_saturation_shift(transformed, saturation_scale=saturation_scale)
     transformed = _apply_downscale_upscale(transformed, factor=downscale_factor)
-    transformed = _apply_gaussian_noise(transformed, sigma=gaussian_sigma, seed=int.from_bytes(digest[10:18], "big"))
+    transformed = _apply_gaussian_noise(
+        transformed,
+        sigma=gaussian_sigma,
+        seed=int.from_bytes(digest[10:18], "big"),
+    )
 
     metadata = TransformMetadata(
         pipeline=TRANSFORM_PIPELINE_NAME,
@@ -54,8 +64,14 @@ def _pick_int(raw: bytes, *, low: int, high: int) -> int:
     return low + (int.from_bytes(raw, "big") % span)
 
 
+def _pick_float(raw: bytes, *, low: float, high: float) -> float:
+    value = int.from_bytes(raw, "big") / 65535.0
+    return low + value * (high - low)
+
+
 def _apply_brightness_contrast(image: np.ndarray, *, alpha: float, beta: int) -> np.ndarray:
-    return cv2.convertScaleAbs(image, alpha=alpha, beta=beta)
+    adjusted = image.astype(np.float32) * alpha + beta
+    return np.clip(adjusted, 0, 255).astype(np.uint8)
 
 
 def _apply_saturation_shift(image: np.ndarray, *, saturation_scale: float) -> np.ndarray:


### PR DESCRIPTION
Update: transformation strength was increased after review feedback, so the generated transformed images are now more visibly distorted while still preserving image geometry and COCO annotations.
If u want more update these (src/murawa/data/variant_image_transforms.py):
brightness_beta:  i.e. -50 to 50
contrast_alpha: i.e. 0.60 to 1.55
saturation_scale: i.e. . 0.40 to 1.75
downscale_factor: i.e. 0.35 to 0.55
gaussian_sigma: i.e. 18.0 to 3

BEFORE
<img width="1920" height="1080" alt="ballextra_train_4b770a_1_5_png rf 1be77ecf075efc591fba389c6fd4664a" src="https://github.com/user-attachments/assets/6245c66a-a6b5-41d2-9fb1-5ddb7aaacca6" />
AFTER
<img width="1920" height="1080" alt="ballextra_train_4b770a_1_5_png rf 1be77ecf075efc591fba389c6fd4664a__tf" src="https://github.com/user-attachments/assets/17e7c7b1-0756-4bda-ac86-5bef4f9b95b3" />

BEFORE
<img width="1920" height="1080" alt="ballextra_train_2e57b9_1_8_png rf d849da7de1bec7f336850bdeb5d7f341" src="https://github.com/user-attachments/assets/aa69a175-4bac-4b47-89a5-3efc209b3c1e" />
AFTER
<img width="1920" height="1080" alt="ballextra_train_2e57b9_1_8_png rf d849da7de1bec7f336850bdeb5d7f341__tf" src="https://github.com/user-attachments/assets/03d63440-7c56-4d0a-bf1f-fd4719dc1c80" />

BEFORE
<img width="1920" height="1080" alt="ballextra_train_4b770a_3_2_png rf 4d813bf7e422b4fda479c45068b3ceb1" src="https://github.com/user-attachments/assets/b1226c03-950a-49db-9c72-3c1792fa4ad8" />
AFTER
<img width="1920" height="1080" alt="ballextra_train_4b770a_3_2_png rf 4d813bf7e422b4fda479c45068b3ceb1__tf" src="https://github.com/user-attachments/assets/f493b7a7-42af-45e2-a563-93125e7fdef8" />

BEFORE
<img width="1280" height="720" alt="ballextra_train_0_pp_jpg rf 2a8fec6ca6a9db5b70cecd3f731513e3" src="https://github.com/user-attachments/assets/b7492a82-d80d-4a97-8899-ccda43c52d38" />
AFTER
<img width="1280" height="720" alt="ballextra_train_0_pp_jpg rf 2a8fec6ca6a9db5b70cecd3f731513e3__tf" src="https://github.com/user-attachments/assets/a1fa4d6b-27c5-47c8-8ffc-bac5bc57decb" />

