### PR TITLE
feat: add jersey color team assignment

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[server]
+fileWatcherType = "poll"

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ Notes:
 - Device is selected by backend/config (`GPU` when available, otherwise `CPU` where supported).
 - Use `--no-amp` to disable AMP for YOLO (recommended when debugging ROCm instability/segfaults).
 - Use `--force-cpu` to force CPU execution regardless of profile config.
-- To force developer fallback mock for YOLO, set `MURAWA_YOLO_MOCK=1` before running scripts.
 - Static training profiles are stored in `configs/train.quick.yaml` and `configs/train.full.yaml`.
 - `quick` uses deterministic representative subsampling inside the requested split (`train`/`valid`) based on the config seed; it does not take the first `N` images and never consults `test`.
 

--- a/app/pages/frame_page.py
+++ b/app/pages/frame_page.py
@@ -23,14 +23,22 @@ def render() -> None:
     uploaded = st.file_uploader(
         "Wgraj klatkę (opcjonalnie)", type=["jpg", "jpeg", "png", "bmp"], key="frame_upload"
     )
+    show_team_debug = st.checkbox(
+        "Wyświetl podgląd rozpoznawania drużyn",
+        value=False,
+        key="frame_show_team_debug",
+    )
 
     if st.button("Uruchom analizę klatki", key="run_frame"):
-        result = analyze_frame_run(
+        st.session_state["frame_last_result"] = analyze_frame_run(
             project_root=ROOT,
             run_name=selected_run.run_name,
             input_path=save_upload(uploaded),
         )
-        show_result(result)
+
+    result = st.session_state.get("frame_last_result")
+    if isinstance(result, dict):
+        show_result(result, show_debug_assets=show_team_debug)
 
 
 if __name__ == "__main__":

--- a/app/ui_common.py
+++ b/app/ui_common.py
@@ -47,7 +47,7 @@ def save_upload(uploaded_file) -> str | None:
         return tmp.name
 
 
-def show_result(result: dict) -> None:
+def show_result(result: dict, show_debug_assets: bool = False) -> None:
     if result["status"] == "missing_run":
         st.info(result["message"])
         return
@@ -68,3 +68,12 @@ def show_result(result: dict) -> None:
         preview_file = Path(asset)
         if preview_file.exists():
             st.image(str(preview_file), caption=preview_file.name, use_container_width=True)
+
+    if not show_debug_assets:
+        return
+
+    debug_assets = result.get("debug_preview_assets", [])
+    for asset in debug_assets[:3]:
+        debug_file = Path(asset)
+        if debug_file.exists():
+            st.image(str(debug_file), caption=debug_file.name, use_container_width=True)

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -53,6 +53,7 @@ def main() -> int:
     logger.info("output=%s", result["output_dir"])
     logger.info("detections=%s", result.get("stats", {}).get("total_detections", 0))
     logger.info("preview_assets=%s", len(result.get("preview_assets", [])))
+    logger.info("debug_preview_assets=%s", len(result.get("debug_preview_assets", [])))
 
     print(
         json.dumps(
@@ -64,6 +65,7 @@ def main() -> int:
                 "resolved_input": result["resolved_input"],
                 "summary_path": result["summary_path"],
                 "preview_assets": result.get("preview_assets", []),
+                "debug_preview_assets": result.get("debug_preview_assets", []),
                 "stats": result.get("stats", {}),
             },
             indent=2,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -2,14 +2,11 @@
 
 import argparse
 import logging
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 
-import torch
-
 from murawa.data import DataLoaderError, load_training_split, summarize_variant
-from murawa.models import build_model, build_training_adapter, normalize_model_name
+from murawa.models import build_training_adapter, normalize_model_name
 from murawa.services.artifacts import (
     ArtifactManifest,
     ArtifactWriteContext,
@@ -62,8 +59,6 @@ def main() -> int:
     config_path = _resolve_profile_config(args.profile)
     run_tag = sanitize_run_tag(args.name)
 
-    use_mock_yolo = model_name == "yolo" and _env_flag("MURAWA_YOLO_MOCK")
-    use_real_adapter = not use_mock_yolo
     artifact_callback = StandardizedArtifactCallback()
     amp_override = False if args.no_amp else None
     device_override = "cpu" if args.force_cpu else None
@@ -84,7 +79,7 @@ def main() -> int:
     sampled_annotations = sum(len(sample.annotations) for sample in loaded_split.samples)
     created_at = datetime.now(timezone.utc)
     run_name = make_run_name(model_name, args.dataset_variant, created_at, tag=run_tag)
-    
+
     ckpt_dir = ROOT / CKPT_DIR / run_name
     meta_dir = ROOT / META_DIR / run_name
     if _non_empty_dir(ckpt_dir) or _non_empty_dir(meta_dir):
@@ -99,41 +94,27 @@ def main() -> int:
     ckpt_dir.mkdir(parents=True, exist_ok=True)
     meta_dir.mkdir(parents=True, exist_ok=True)
 
-    if use_real_adapter:
-        model_impl = build_training_adapter(model_name)
-        train_kwargs = {
-            "config_path": config_path,
-            "output_dir": ckpt_dir,
-            "artifact_callback": artifact_callback,
-            "device": device_override,
-        }
-        if model_name == "yolo":
-            train_kwargs["amp"] = amp_override
-        train_result = model_impl.train(args.dataset_variant, **train_kwargs)
-        if train_result is None:
-            train_result = {}
-        checkpoint_path = Path(
-            train_result.get("weights", {}).get("checkpoint_path", str(ckpt_dir / "model.pt"))
-        ).resolve()
-        if checkpoint_path != (ckpt_dir / "model.pt").resolve():
-            logger.error("%s adapter returned checkpoint outside standard path: %s", model_name, checkpoint_path)
-            return 1
-        if not checkpoint_path.exists() or not checkpoint_path.is_file():
-            logger.error("%s adapter did not produce a valid checkpoint at: %s", model_name, checkpoint_path)
-            return 1
-        is_mock_run = bool(train_result.get("mock", False))
-        
-    else:
-        model_impl = build_model(model_name)
-        train_result = model_impl.train(args.dataset_variant)
-        if train_result is None:
-            train_result = {"weights": {}}
-        checkpoint_path = ckpt_dir / "model.pt"
-        torch.save(
-            {"mock": True, "model": model_name, "weights": train_result.get("weights", {})},
-            checkpoint_path,
-        )
-        is_mock_run = True
+    model_impl = build_training_adapter(model_name)
+    train_kwargs = {
+        "config_path": config_path,
+        "output_dir": ckpt_dir,
+        "artifact_callback": artifact_callback,
+        "device": device_override,
+    }
+    if model_name == "yolo":
+        train_kwargs["amp"] = amp_override
+    train_result = model_impl.train(args.dataset_variant, **train_kwargs)
+    if train_result is None:
+        train_result = {}
+    checkpoint_path = Path(
+        train_result.get("weights", {}).get("checkpoint_path", str(ckpt_dir / "model.pt"))
+    ).resolve()
+    if checkpoint_path != (ckpt_dir / "model.pt").resolve():
+        logger.error("%s adapter returned checkpoint outside standard path: %s", model_name, checkpoint_path)
+        return 1
+    if not checkpoint_path.exists() or not checkpoint_path.is_file():
+        logger.error("%s adapter did not produce a valid checkpoint at: %s", model_name, checkpoint_path)
+        return 1
 
     cfg_found = save_config(config_path, meta_dir / "config.yaml", model_name, args.dataset_variant)
 
@@ -150,17 +131,14 @@ def main() -> int:
     valid_samples = int(train_result.get("valid_samples", 0))
     train_sampling_summary = dict(train_result.get("train_sampling_summary", {}))
     valid_sampling_summary = dict(train_result.get("valid_sampling_summary", {}))
-    backend_name = str(train_result.get("backend", "mock"))
+    backend_name = str(train_result.get("backend", model_name))
     train_device = str(train_result.get("train_device", "cpu"))
     valid_split_source = str(train_result.get("valid_split_source", "valid"))
     note = str(train_result.get("note", f"{model_name} training finished."))
     train_amp = train_result.get("train_amp")
-    if train_amp is None:
-        if model_name == "yolo" and not is_mock_run:
-            train_amp = False if args.no_amp else True
-        else:
-            train_amp = None
-    train_device = "cpu" if args.force_cpu and not is_mock_run else train_device
+    if train_amp is None and model_name == "yolo":
+        train_amp = False if args.no_amp else True
+    train_device = "cpu" if args.force_cpu else train_device
 
     try:
         variant_summary_payload = summarize_variant(ROOT, args.dataset_variant).to_dict()
@@ -200,9 +178,7 @@ def main() -> int:
             "train_samples": train_samples,
             "valid_samples": valid_samples,
             "valid_split_source": valid_split_source,
-            "is_mock_run": is_mock_run,
             "model_impl": model_impl.__class__.__name__,
-            "mock_note": note if is_mock_run else "",
             "loader_summary": {
                 "validated_split": loaded_split.split,
                 "preflight_checked_images": len(loaded_split.samples),
@@ -239,8 +215,6 @@ def main() -> int:
     logger.info("amp=%s", train_amp if train_amp is not None else "n/a")
     logger.info("checkpoint=%s", checkpoint_path)
     logger.info("metadata=%s", meta_dir)
-    if use_mock_yolo:
-        logger.info("MURAWA_YOLO_MOCK is enabled. YOLO mock model was used.")
     return 0
 
 
@@ -249,11 +223,6 @@ def _resolve_profile_config(profile: str) -> Path:
     if not config_path.exists() or not config_path.is_file():
         raise FileNotFoundError(f"Config profile file not found: {config_path}")
     return config_path
-
-
-def _env_flag(name: str) -> bool:
-    value = os.environ.get(name, "")
-    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _non_empty_dir(path: Path) -> bool:

--- a/src/murawa/models/__init__.py
+++ b/src/murawa/models/__init__.py
@@ -1,3 +1,3 @@
-from murawa.models.factory import build_model, build_training_adapter, normalize_model_name
+from murawa.models.factory import build_training_adapter, normalize_model_name
 
-__all__ = ["build_model", "build_training_adapter", "normalize_model_name"]
+__all__ = ["build_training_adapter", "normalize_model_name"]

--- a/src/murawa/models/factory.py
+++ b/src/murawa/models/factory.py
@@ -1,5 +1,5 @@
 from murawa.models.rfdetr import RfDetrAdapter
-from murawa.models.yolo import YoloAdapter, YoloMockModel
+from murawa.models.yolo import YoloAdapter
 
 SUPPORTED_MODELS = {"yolo", "rfdetr"}
 
@@ -13,15 +13,7 @@ def normalize_model_name(model: str) -> str:
     return normalized
 
 
-def build_model(model: str):
-    normalized = normalize_model_name(model)
-    if normalized == "yolo":
-        return YoloMockModel()
-    return RfDetrAdapter()
-
-
 def build_training_adapter(model: str):
-    """Issue #10/#11: return non-mock adapter contract for real training integration."""
     normalized = normalize_model_name(model)
     if normalized == "yolo":
         return YoloAdapter()

--- a/src/murawa/models/rfdetr.py
+++ b/src/murawa/models/rfdetr.py
@@ -14,6 +14,7 @@ from typing import Any
 import warnings
 
 import cv2
+import numpy as np
 import yaml
 
 from murawa.data import DataLoaderError, LoadedSplit, load_training_split
@@ -170,7 +171,6 @@ class RfDetrAdapter:
             },
             "metrics": metrics,
             "note": note,
-            "mock": False,
             "backend": self.backend,
             "rfdetr_variant": cfg["variant"],
             "train_device": str(cfg["device"]),
@@ -217,7 +217,8 @@ class RfDetrAdapter:
                 raise ValueError(
                     f"Frame mode requires an image file. Received suffix='{input_path.suffix}'."
                 )
-            detections = _predict_image(model=model, image=str(input_path), threshold=detection_confidence)
+            frame_rgb = _read_frame_image_rgb(input_path)
+            detections = _predict_image(model=model, image=frame_rgb, threshold=detection_confidence)
             return _convert_detections_to_frame_schema(detections, class_mapping)
 
         if input_path.suffix.lower() not in VIDEO_SUFFIXES:
@@ -790,6 +791,13 @@ def _predict_image(model, image: Any, threshold: float):
             raise RuntimeError(f"RF-DETR returned {len(detections)} detection batches for one input.")
         return detections[0]
     return detections
+
+
+def _read_frame_image_rgb(input_path: Path) -> np.ndarray:
+    image_bgr = cv2.imread(str(input_path), cv2.IMREAD_COLOR)
+    if image_bgr is None:
+        raise RuntimeError(f"Could not read frame image for RF-DETR prediction: {input_path}")
+    return cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
 
 
 def _convert_detections_to_frame_schema(detections: Any, class_mapping: dict[int, str]) -> list[dict]:

--- a/src/murawa/models/yolo.py
+++ b/src/murawa/models/yolo.py
@@ -16,29 +16,6 @@ from murawa.services.artifacts import StandardizedArtifactCallback
 
 
 @dataclass
-class YoloMockModel:
-    name: str = "yolo"
-
-    def train(self, dataset_variant: str) -> dict:
-        return {
-            "weights": {"head.cls": [0.21, 0.37, 0.11]},
-            "metrics": {"epochs": 1, "loss": 1.04, "mAP50": 0.23},
-            "note": f"YOLO mock trained on {dataset_variant}",
-        }
-
-    def predict(self, mode: str) -> list[dict]:
-        if mode == "frame":
-            return [
-                {"class": "player", "confidence": 0.91, "bbox_xyxy": [120, 80, 260, 360]},
-                {"class": "ball", "confidence": 0.74, "bbox_xyxy": [342, 210, 358, 226]},
-            ]
-        return [
-            {"frame_index": 10, "class": "player", "confidence": 0.88, "track_id": 4},
-            {"frame_index": 11, "class": "ball", "confidence": 0.72, "track_id": 99},
-        ]
-
-
-@dataclass
 class YoloAdapter:
     """Issue #10: target integration layer for real YOLO backend."""
 
@@ -165,7 +142,6 @@ class YoloAdapter:
             },
             "metrics": metrics,
             "note": note,
-            "mock": False,
             "backend": self.backend,
             "train_device": str(cfg["device"]) if cfg["device"] is not None else "auto",
             "train_amp": bool(cfg["amp"]),

--- a/src/murawa/services/artifacts.py
+++ b/src/murawa/services/artifacts.py
@@ -56,7 +56,7 @@ def save_config(src: Path, dst: Path, model: str, dataset_variant: str) -> bool:
     dst.write_text(
         "\n".join(
             [
-                "# Auto-generated fallback config for MVP mock",
+                "# Auto-generated fallback config",
                 f"model: {model}",
                 f"dataset_variant: {dataset_variant}",
                 "epochs: 1",

--- a/src/murawa/services/pipeline.py
+++ b/src/murawa/services/pipeline.py
@@ -6,8 +6,13 @@ import numpy as np
 from murawa.data.path_resolver import IMAGE_SUFFIXES, PREDICTIONS_ROOT, VIDEO_SUFFIXES, pick_input
 from murawa.models import build_training_adapter, normalize_model_name
 from murawa.services.artifacts import latest_run, resolve_run, write_json
-from murawa.vision.team_assignment import assign_teams_to_frame
-from murawa.vision.team_assignment_helpers import read_bbox_xyxy, team_preview_color_bgr
+from murawa.vision.team_assignment import PLAYER_CLASSES, REFEREE_CLASSES, assign_teams_to_frame
+from murawa.vision.team_assignment_helpers import (
+    crop_jersey_region,
+    normalize_class_name,
+    read_bbox_xyxy,
+    team_preview_color_bgr,
+)
 
 
 def analyze_frame(
@@ -170,14 +175,22 @@ def _run_analysis_for_run(
 
     stats = _build_detection_stats(detections=detections, mode=mode)
     preview_assets: list[str] = []
+    debug_preview_assets: list[str] = []
 
     preview_assets = _write_preview_assets(
         input_path=resolved_path,
         detections=detections,
         mode=mode,
         out_dir=out_dir,
+        team_assignment=team_assignment,
         frame_image_bgr=frame_image_bgr.copy() if frame_image_bgr is not None else None,
     )
+    if mode == "frame" and frame_image_bgr is not None:
+        debug_preview_assets = _write_team_assignment_debug_preview(
+            frame_image_bgr=frame_image_bgr,
+            detections=detections,
+            out_dir=out_dir,
+        )
 
     payload = {
         "status": "ok",
@@ -193,6 +206,7 @@ def _run_analysis_for_run(
         "summary_path": str(summary_path),
         "preview_path": str(preview_path),
         "preview_assets": preview_assets,
+        "debug_preview_assets": debug_preview_assets,
         "stats": stats,
         "team_assignment": team_assignment,
         "minimap_entities": minimap_entities,
@@ -210,6 +224,7 @@ def _run_analysis_for_run(
                 f"detections={stats.get('total_detections', 0)}",
                 f"classes={stats.get('classes', {})}",
                 f"preview_assets={len(preview_assets)}",
+                f"debug_preview_assets={len(debug_preview_assets)}",
                 "Real adapter output.",
                 "",
             ]
@@ -231,6 +246,7 @@ def _make_base_payload(mode: str, model: str, dataset_variant: str) -> dict:
         "summary_path": "",
         "preview_path": "",
         "preview_assets": [],
+        "debug_preview_assets": [],
         "stats": {},
         "detections": [],
     }
@@ -276,6 +292,7 @@ def _write_preview_assets(
     detections: list[dict],
     mode: str,
     out_dir: Path,
+    team_assignment: dict | None = None,
     frame_image_bgr: np.ndarray | None = None,
 ) -> list[str]:
     preview_dir = out_dir / "preview"
@@ -289,6 +306,7 @@ def _write_preview_assets(
                 frame_image_bgr=frame_image_bgr,
                 detections=detections,
                 preview_dir=preview_dir,
+                team_assignment=team_assignment or {},
             )
         if mode == "match":
             return _write_match_preview(input_path=input_path, detections=detections, preview_dir=preview_dir)
@@ -302,6 +320,7 @@ def _write_frame_preview(
     frame_image_bgr: np.ndarray,
     detections: list[dict],
     preview_dir: Path,
+    team_assignment: dict,
 ) -> list[str]:
     for detection in detections:
         bbox = read_bbox_xyxy(detection)
@@ -330,10 +349,16 @@ def _write_frame_preview(
             2,
         )
 
+    legend_bottom = _draw_team_legend(
+        image_bgr=frame_image_bgr,
+        team_counts=team_assignment.get("team_counts", {}),
+        team_colors_bgr=team_assignment.get("team_colors_bgr", {}),
+    )
+
     cv2.putText(
         frame_image_bgr,
         f"detections={len(detections)}",
-        (10, 22),
+        (10, legend_bottom + 24),
         cv2.FONT_HERSHEY_SIMPLEX,
         0.6,
         (255, 255, 255),
@@ -345,6 +370,179 @@ def _write_frame_preview(
         return []
 
     return [str(preview_path)]
+
+
+def _draw_team_legend(
+    image_bgr: np.ndarray,
+    team_counts: object,
+    team_colors_bgr: object,
+) -> int:
+    counts = team_counts if isinstance(team_counts, dict) else {}
+    team_colors = team_colors_bgr if isinstance(team_colors_bgr, dict) else {}
+    teams = ["team_a", "team_b", "referee"]
+
+    x = 10
+    y = 10
+    row_height = 24
+    width = 170
+    height = 12 + row_height * len(teams)
+    bottom = y + height
+
+    overlay = image_bgr.copy()
+    cv2.rectangle(overlay, (x, y), (x + width, bottom), (0, 0, 0), -1)
+    cv2.addWeighted(overlay, 0.55, image_bgr, 0.45, 0, image_bgr)
+
+    for row_idx, team in enumerate(teams):
+        row_y = y + 22 + row_idx * row_height
+        swatch_color = _legend_color_bgr(team, team_colors)
+        cv2.rectangle(image_bgr, (x + 10, row_y - 13), (x + 26, row_y + 3), swatch_color, -1)
+        cv2.rectangle(image_bgr, (x + 10, row_y - 13), (x + 26, row_y + 3), (255, 255, 255), 1)
+        label = f"{team} {int(counts.get(team, 0))}"
+        cv2.putText(
+            image_bgr,
+            label,
+            (x + 34, row_y),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.52,
+            (255, 255, 255),
+            1,
+        )
+
+    return bottom
+
+
+def _legend_color_bgr(team: str, team_colors_bgr: dict) -> tuple[int, int, int]:
+    color = team_colors_bgr.get(team)
+    if isinstance(color, list) and len(color) == 3:
+        try:
+            return tuple(int(value) for value in color)
+        except (TypeError, ValueError):
+            pass
+    return team_preview_color_bgr(team)
+
+
+def _write_team_assignment_debug_preview(
+    frame_image_bgr: np.ndarray,
+    detections: list[dict],
+    out_dir: Path,
+) -> list[str]:
+    preview_dir = out_dir / "preview"
+    preview_dir.mkdir(parents=True, exist_ok=True)
+
+    debug_image = _build_team_assignment_crop_sheet(frame_image_bgr, detections)
+    debug_path = preview_dir / "team_assignment_crops.jpg"
+    if not cv2.imwrite(str(debug_path), debug_image):
+        return []
+    return [str(debug_path)]
+
+
+def _build_team_assignment_crop_sheet(frame_image_bgr: np.ndarray, detections: list[dict]) -> np.ndarray:
+    tile_width = 170
+    tile_height = 116
+    crop_size = 64
+    columns = 4
+    padding = 10
+
+    debug_items = _team_assignment_debug_items(frame_image_bgr, detections)
+    if not debug_items:
+        image = np.full((90, 380, 3), 32, dtype=np.uint8)
+        cv2.putText(
+            image,
+            "no team assignment crops",
+            (16, 50),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.65,
+            (240, 240, 240),
+            2,
+        )
+        return image
+
+    rows = int(np.ceil(len(debug_items) / columns))
+    sheet_height = padding + rows * tile_height
+    sheet_width = padding + columns * tile_width
+    sheet = np.full((sheet_height, sheet_width, 3), 32, dtype=np.uint8)
+
+    for idx, item in enumerate(debug_items):
+        col = idx % columns
+        row = idx // columns
+        x = padding + col * tile_width
+        y = padding + row * tile_height
+
+        cv2.rectangle(sheet, (x, y), (x + tile_width - 8, y + tile_height - 8), (58, 58, 58), -1)
+        crop = cv2.resize(item["crop"], (crop_size, crop_size), interpolation=cv2.INTER_AREA)
+        sheet[y + 8 : y + 8 + crop_size, x + 8 : x + 8 + crop_size] = crop
+
+        label = item["team"]
+        confidence = item.get("team_confidence")
+        if isinstance(confidence, (int, float)):
+            label = f"{label} {float(confidence):.2f}"
+        cv2.putText(
+            sheet,
+            label,
+            (x + 8, y + 88),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.48,
+            (245, 245, 245),
+            1,
+        )
+        cv2.putText(
+            sheet,
+            item["class_name"],
+            (x + 8, y + 106),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.42,
+            (190, 190, 190),
+            1,
+        )
+
+        jersey_color = item.get("jersey_color_bgr")
+        if jersey_color is not None:
+            cv2.rectangle(sheet, (x + 82, y + 12), (x + 126, y + 38), jersey_color, -1)
+            cv2.rectangle(sheet, (x + 82, y + 12), (x + 126, y + 38), (255, 255, 255), 1)
+
+    return sheet
+
+
+def _team_assignment_debug_items(
+    frame_image_bgr: np.ndarray,
+    detections: list[dict],
+) -> list[dict]:
+    items: list[dict] = []
+
+    for det in detections:
+        class_name = normalize_class_name(det.get("class"))
+        if class_name not in PLAYER_CLASSES and class_name not in REFEREE_CLASSES:
+            continue
+
+        bbox = read_bbox_xyxy(det)
+        if bbox is None:
+            continue
+
+        crop = crop_jersey_region(frame_image_bgr, bbox)
+        if crop.size == 0:
+            continue
+
+        jersey_color = _read_color_bgr(det.get("jersey_color_bgr"))
+        items.append(
+            {
+                "class_name": class_name,
+                "team": str(det.get("team", "unknown")),
+                "team_confidence": det.get("team_confidence"),
+                "jersey_color_bgr": jersey_color,
+                "crop": crop,
+            }
+        )
+
+    return items
+
+
+def _read_color_bgr(value: object) -> tuple[int, int, int] | None:
+    if not isinstance(value, list) or len(value) != 3:
+        return None
+    try:
+        return tuple(int(channel) for channel in value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _write_match_preview(input_path: Path, detections: list[dict], preview_dir: Path) -> list[str]:
@@ -401,6 +599,7 @@ def _write_match_preview(input_path: Path, detections: list[dict], preview_dir: 
         cap.release()
 
     return assets
+
 
 def _resolve_input(
     project_root: Path, mode: str, dataset_variant: str, input_path: str | None

--- a/src/murawa/services/pipeline.py
+++ b/src/murawa/services/pipeline.py
@@ -1,12 +1,14 @@
-import os
 from pathlib import Path
 
 import cv2
+import numpy as np
 
 from murawa.data.path_resolver import IMAGE_SUFFIXES, PREDICTIONS_ROOT, VIDEO_SUFFIXES, pick_input
-from murawa.models import build_model, build_training_adapter, normalize_model_name
+from murawa.models import build_training_adapter, normalize_model_name
 from murawa.services.artifacts import latest_run, resolve_run, write_json
-from murawa.vision.team_assignment import assign_teams_to_frame, team_color_bgr
+from murawa.vision.team_assignment import assign_teams_to_frame
+from murawa.vision.team_assignment_helpers import read_bbox_xyxy, team_preview_color_bgr
+
 
 def analyze_frame(
     project_root: Path, model: str, dataset_variant: str, input_path: str | None = None
@@ -86,12 +88,7 @@ def _run_analysis_for_run(
     resolved_input, input_found = _resolve_input(project_root, mode, dataset_variant, input_path)
     checkpoint_path = run.checkpoint_path
 
-    # Shared flags for inference mode
-    use_real_yolo = normalized_model == "yolo" and not _env_flag("MURAWA_YOLO_MOCK")
-    use_rf_detr = normalized_model == "rfdetr"
-    use_real_inference = use_real_yolo or use_rf_detr
-
-    if use_real_inference and not input_found:
+    if not input_found:
         expected = "image" if mode == "frame" else "video"
         base_payload["status"] = "error"
         base_payload["resolved_input"] = resolved_input
@@ -102,55 +99,51 @@ def _run_analysis_for_run(
         return base_payload
 
     resolved_path = Path(resolved_input) if resolved_input else None
-    
-    if use_real_inference:
-        if resolved_path is None or not resolved_path.exists() or not resolved_path.is_file():
-            base_payload["status"] = "error"
-            base_payload["resolved_input"] = resolved_input
-            base_payload["message"] = (
-                f"Input path for {normalized_model} backend must point to a file. "
-                f"Received: {resolved_input}"
-            )
-            return base_payload
 
-        suffix = resolved_path.suffix.lower()
-        if mode == "frame" and suffix not in IMAGE_SUFFIXES:
-            base_payload["status"] = "error"
-            base_payload["resolved_input"] = resolved_input
-            base_payload["message"] = (
-                f"Frame mode requires an image file. Received suffix='{suffix}', "
-                f"expected one of {sorted(IMAGE_SUFFIXES)}."
-            )
-            return base_payload
+    if resolved_path is None or not resolved_path.exists() or not resolved_path.is_file():
+        base_payload["status"] = "error"
+        base_payload["resolved_input"] = resolved_input
+        base_payload["message"] = (
+            f"Input path for {normalized_model} backend must point to a file. "
+            f"Received: {resolved_input}"
+        )
+        return base_payload
 
-        if mode == "match" and suffix not in VIDEO_SUFFIXES:
+    suffix = resolved_path.suffix.lower()
+    if mode == "frame" and suffix not in IMAGE_SUFFIXES:
+        base_payload["status"] = "error"
+        base_payload["resolved_input"] = resolved_input
+        base_payload["message"] = (
+            f"Frame mode requires an image file. Received suffix='{suffix}', "
+            f"expected one of {sorted(IMAGE_SUFFIXES)}."
+        )
+        return base_payload
+
+    if mode == "match" and suffix not in VIDEO_SUFFIXES:
+        base_payload["status"] = "error"
+        base_payload["resolved_input"] = resolved_input
+        base_payload["message"] = (
+            f"Match mode requires a video file. Received suffix='{suffix}', "
+            f"expected one of {sorted(VIDEO_SUFFIXES)}."
+        )
+        return base_payload
+
+    frame_image_bgr = None
+    if mode == "frame":
+        frame_image_bgr = cv2.imread(str(resolved_path), cv2.IMREAD_COLOR)
+        if frame_image_bgr is None:
             base_payload["status"] = "error"
             base_payload["resolved_input"] = resolved_input
-            base_payload["message"] = (
-                f"Match mode requires a video file. Received suffix='{suffix}', "
-                f"expected one of {sorted(VIDEO_SUFFIXES)}."
-            )
+            base_payload["message"] = f"Could not read frame image: {resolved_input}"
             return base_payload
 
     try:
-        if use_rf_detr:
-            model_instance = build_training_adapter(normalized_model)
-            detections = model_instance.predict(
-                input_path=resolved_path,
-                checkpoint_path=checkpoint_path,
-                mode=mode
-            )
-            is_mock = False
-        elif use_real_yolo:
-            detections = build_training_adapter(normalized_model).predict(
-                input_path=resolved_path,
-                checkpoint_path=checkpoint_path,
-                mode=mode,
-            )
-            is_mock = False
-        else:
-            detections = build_model(normalized_model).predict(mode)
-            is_mock = True
+        model_instance = build_training_adapter(normalized_model)
+        detections = model_instance.predict(
+            input_path=resolved_path,
+            checkpoint_path=checkpoint_path,
+            mode=mode,
+        )
     except Exception as exc:
         base_payload["status"] = "error"
         base_payload["resolved_input"] = resolved_input
@@ -166,9 +159,9 @@ def _run_analysis_for_run(
     }
     minimap_entities: list[dict] = []
 
-    if mode == "frame" and use_real_inference and resolved_path is not None:
+    if mode == "frame" and frame_image_bgr is not None:
         assignment_result = assign_teams_to_frame(
-            image_path=resolved_path,
+            image_bgr=frame_image_bgr,
             detections=detections,
         )
         detections = assignment_result.detections
@@ -177,18 +170,17 @@ def _run_analysis_for_run(
 
     stats = _build_detection_stats(detections=detections, mode=mode)
     preview_assets: list[str] = []
-    
-    if use_real_inference and resolved_path is not None:
-        preview_assets = _write_preview_assets(
-            input_path=resolved_path,
-            detections=detections,
-            mode=mode,
-            out_dir=out_dir,
-        )
+
+    preview_assets = _write_preview_assets(
+        input_path=resolved_path,
+        detections=detections,
+        mode=mode,
+        out_dir=out_dir,
+        frame_image_bgr=frame_image_bgr.copy() if frame_image_bgr is not None else None,
+    )
 
     payload = {
         "status": "ok",
-        "mock": is_mock,
         "mode": mode,
         "model": normalized_model,
         "dataset_variant": dataset_variant,
@@ -218,7 +210,7 @@ def _run_analysis_for_run(
                 f"detections={stats.get('total_detections', 0)}",
                 f"classes={stats.get('classes', {})}",
                 f"preview_assets={len(preview_assets)}",
-                "Mock prediction output placeholder." if is_mock else "Real adapter output.",
+                "Real adapter output.",
                 "",
             ]
         ),
@@ -284,13 +276,20 @@ def _write_preview_assets(
     detections: list[dict],
     mode: str,
     out_dir: Path,
+    frame_image_bgr: np.ndarray | None = None,
 ) -> list[str]:
     preview_dir = out_dir / "preview"
     preview_dir.mkdir(parents=True, exist_ok=True)
 
     try:
         if mode == "frame":
-            return _write_frame_preview(input_path=input_path, detections=detections, preview_dir=preview_dir)
+            if frame_image_bgr is None:
+                return []
+            return _write_frame_preview(
+                frame_image_bgr=frame_image_bgr,
+                detections=detections,
+                preview_dir=preview_dir,
+            )
         if mode == "match":
             return _write_match_preview(input_path=input_path, detections=detections, preview_dir=preview_dir)
     except Exception:
@@ -299,34 +298,30 @@ def _write_preview_assets(
     return []
 
 
-def _write_frame_preview(input_path: Path, detections: list[dict], preview_dir: Path) -> list[str]:
-    image = cv2.imread(str(input_path))
-    if image is None:
-        return []
-
+def _write_frame_preview(
+    frame_image_bgr: np.ndarray,
+    detections: list[dict],
+    preview_dir: Path,
+) -> list[str]:
     for detection in detections:
-        bbox = detection.get("bbox_xyxy")
-        if not isinstance(bbox, list) or len(bbox) != 4:
+        bbox = read_bbox_xyxy(detection)
+        if bbox is None:
             continue
 
-        try:
-            x1, y1, x2, y2 = [int(v) for v in bbox]
-        except (TypeError, ValueError):
-            continue
-
+        x1, y1, x2, y2 = bbox
         class_name = str(detection.get("class", "unknown"))
         confidence = detection.get("confidence")
         confidence_text = f" {float(confidence):.2f}" if isinstance(confidence, (int, float)) else ""
 
-        team = str(detection.get("team", "not_applicable"))
-        color = team_color_bgr(team)
+        team = str(detection.get("team", "unknown"))
+        color = team_preview_color_bgr(team)
         label = f"{class_name}{confidence_text}"
-        if team not in {"not_applicable", "unknown"}:
+        if team != "unknown":
             label = f"{label} {team}"
 
-        cv2.rectangle(image, (x1, y1), (x2, y2), color, 2)
+        cv2.rectangle(frame_image_bgr, (x1, y1), (x2, y2), color, 2)
         cv2.putText(
-            image,
+            frame_image_bgr,
             label,
             (x1, max(15, y1 - 6)),
             cv2.FONT_HERSHEY_SIMPLEX,
@@ -336,7 +331,7 @@ def _write_frame_preview(input_path: Path, detections: list[dict], preview_dir: 
         )
 
     cv2.putText(
-        image,
+        frame_image_bgr,
         f"detections={len(detections)}",
         (10, 22),
         cv2.FONT_HERSHEY_SIMPLEX,
@@ -346,7 +341,7 @@ def _write_frame_preview(input_path: Path, detections: list[dict], preview_dir: 
     )
 
     preview_path = preview_dir / "frame_preview.jpg"
-    if not cv2.imwrite(str(preview_path), image):
+    if not cv2.imwrite(str(preview_path), frame_image_bgr):
         return []
 
     return [str(preview_path)]
@@ -406,12 +401,6 @@ def _write_match_preview(input_path: Path, detections: list[dict], preview_dir: 
         cap.release()
 
     return assets
-
-
-def _env_flag(name: str) -> bool:
-    value = os.environ.get(name, "")
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
 
 def _resolve_input(
     project_root: Path, mode: str, dataset_variant: str, input_path: str | None

--- a/src/murawa/services/pipeline.py
+++ b/src/murawa/services/pipeline.py
@@ -6,7 +6,7 @@ import cv2
 from murawa.data.path_resolver import IMAGE_SUFFIXES, PREDICTIONS_ROOT, VIDEO_SUFFIXES, pick_input
 from murawa.models import build_model, build_training_adapter, normalize_model_name
 from murawa.services.artifacts import latest_run, resolve_run, write_json
-
+from murawa.vision.team_assignment import assign_teams_to_frame, team_color_bgr
 
 def analyze_frame(
     project_root: Path, model: str, dataset_variant: str, input_path: str | None = None
@@ -160,6 +160,21 @@ def _run_analysis_for_run(
     summary_path = out_dir / "prediction_summary.json"
     preview_path = out_dir / f"{mode}_prediction.txt"
 
+    team_assignment = {
+        "enabled": False,
+        "reason": "Team assignment is available only for frame image inputs in this MVP.",
+    }
+    minimap_entities: list[dict] = []
+
+    if mode == "frame" and use_real_inference and resolved_path is not None:
+        assignment_result = assign_teams_to_frame(
+            image_path=resolved_path,
+            detections=detections,
+        )
+        detections = assignment_result.detections
+        team_assignment = assignment_result.summary
+        minimap_entities = assignment_result.minimap_entities
+
     stats = _build_detection_stats(detections=detections, mode=mode)
     preview_assets: list[str] = []
     
@@ -187,6 +202,8 @@ def _run_analysis_for_run(
         "preview_path": str(preview_path),
         "preview_assets": preview_assets,
         "stats": stats,
+        "team_assignment": team_assignment,
+        "minimap_entities": minimap_entities,
         "detections": detections,
     }
     write_json(summary_path, payload)
@@ -301,14 +318,20 @@ def _write_frame_preview(input_path: Path, detections: list[dict], preview_dir: 
         confidence = detection.get("confidence")
         confidence_text = f" {float(confidence):.2f}" if isinstance(confidence, (int, float)) else ""
 
-        cv2.rectangle(image, (x1, y1), (x2, y2), (0, 220, 255), 2)
+        team = str(detection.get("team", "not_applicable"))
+        color = team_color_bgr(team)
+        label = f"{class_name}{confidence_text}"
+        if team not in {"not_applicable", "unknown"}:
+            label = f"{label} {team}"
+
+        cv2.rectangle(image, (x1, y1), (x2, y2), color, 2)
         cv2.putText(
             image,
-            f"{class_name}{confidence_text}",
+            label,
             (x1, max(15, y1 - 6)),
             cv2.FONT_HERSHEY_SIMPLEX,
             0.5,
-            (0, 220, 255),
+            color,
             2,
         )
 

--- a/src/murawa/vision/team_assignment.py
+++ b/src/murawa/vision/team_assignment.py
@@ -98,6 +98,7 @@ def assign_teams_to_frame(
             "min_player_confidence": MIN_PLAYER_CONFIDENCE,
         },
         "team_counts": _count_player_teams(enriched),
+        "team_colors_bgr": _summarize_team_colors(enriched),
         "minimap_entities": len(minimap_entities),
         "notes": [
             "Team assignment is heuristic and based on jersey color crops.",
@@ -157,6 +158,32 @@ def _count_player_teams(detections: list[dict[str, Any]]) -> dict[str, int]:
         team_counts[str(det.get("team", "unknown"))] += 1
 
     return dict(sorted(team_counts.items()))
+
+
+def _summarize_team_colors(detections: list[dict[str, Any]]) -> dict[str, list[int]]:
+    colors_by_team: dict[str, list[list[int]]] = {"team_a": [], "team_b": []}
+
+    for det in detections:
+        team = det.get("team")
+        jersey_color = det.get("jersey_color_bgr")
+        if team not in colors_by_team:
+            continue
+        if not isinstance(jersey_color, list) or len(jersey_color) != 3:
+            continue
+
+        try:
+            colors_by_team[str(team)].append([int(value) for value in jersey_color])
+        except (TypeError, ValueError):
+            continue
+
+    team_colors: dict[str, list[int]] = {}
+    for team, colors in colors_by_team.items():
+        if not colors:
+            continue
+        median_color = np.median(np.array(colors, dtype=np.uint8), axis=0)
+        team_colors[team] = [int(round(float(value))) for value in median_color.tolist()]
+
+    return team_colors
 
 
 def _build_minimap_entities(detections: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/murawa/vision/team_assignment.py
+++ b/src/murawa/vision/team_assignment.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+
+
+PLAYER_CLASSES = {"player", "goalkeeper"}
+REFEREE_CLASSES = {"referee"}
+
+
+@dataclass(frozen=True)
+class TeamAssignmentResult:
+    detections: list[dict[str, Any]]
+    summary: dict[str, Any]
+    minimap_entities: list[dict[str, Any]]
+
+
+def assign_teams_to_frame(image_path: Path, detections: list[dict[str, Any]]) -> TeamAssignmentResult:
+    """Assign player detections to teams using jersey colors.
+
+    This is an MVP heuristic intended for post-processing model predictions.
+    It does not train any new model. It uses bbox crops, estimates jersey color,
+    clusters players into two teams, and keeps referee/unknown separately.
+    """
+    image = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
+    if image is None:
+        return TeamAssignmentResult(
+            detections=detections,
+            summary={
+                "enabled": False,
+                "reason": f"Could not read image: {image_path}",
+                "team_counts": {},
+            },
+            minimap_entities=[],
+        )
+
+    enriched = [dict(det) for det in detections]
+    player_items: list[tuple[int, np.ndarray]] = []
+
+    for idx, det in enumerate(enriched):
+        class_name = _normalize_class(det.get("class"))
+
+        if class_name in REFEREE_CLASSES:
+            det["team"] = "referee"
+            det["team_confidence"] = 1.0
+            continue
+
+        if class_name not in PLAYER_CLASSES:
+            det["team"] = "not_applicable"
+            det["team_confidence"] = 1.0
+            continue
+
+        bbox = _read_bbox(det)
+        if bbox is None:
+            det["team"] = "unknown"
+            det["team_confidence"] = 0.0
+            continue
+
+        x1, y1, x2, y2 = bbox
+        box_w = x2 - x1
+        box_h = y2 - y1
+        confidence = float(det.get("confidence", 0.0))
+
+        # Very small / low-confidence partial detections usually hurt color clustering.
+        if box_w < 15 or box_h < 35 or confidence < 0.45:
+            det["team"] = "unknown"
+            det["team_confidence"] = 0.0
+            continue
+
+        jersey_crop = _crop_jersey_region(image, bbox)
+        color = _estimate_jersey_color_bgr(jersey_crop)
+        if color is None:
+            det["team"] = "unknown"
+            det["team_confidence"] = 0.0
+            continue
+
+        det["jersey_color_bgr"] = [int(v) for v in color.tolist()]
+        player_items.append((idx, color.astype(np.float32)))
+
+    team_labels = _cluster_two_teams(player_items)
+
+    for idx, label, confidence in team_labels:
+        enriched[idx]["team"] = label
+        enriched[idx]["team_confidence"] = round(float(confidence), 4)
+
+    enriched = _smooth_by_track_id(enriched)
+    minimap_entities = _build_minimap_entities(enriched)
+
+    team_counts = Counter(str(det.get("team", "unknown")) for det in enriched)
+    summary = {
+        "enabled": True,
+        "method": "jersey_color_kmeans_mvp",
+        "player_classes": sorted(PLAYER_CLASSES),
+        "referee_classes": sorted(REFEREE_CLASSES),
+        "team_counts": dict(sorted(team_counts.items())),
+        "minimap_entities": len(minimap_entities),
+        "notes": [
+            "Team assignment is heuristic and based on jersey color crops.",
+            "Referee is kept separately when the model predicts class='referee'.",
+            "Track smoothing is applied when track_id is available.",
+        ],
+    }
+
+    return TeamAssignmentResult(
+        detections=enriched,
+        summary=summary,
+        minimap_entities=minimap_entities,
+    )
+
+
+def _normalize_class(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def _read_bbox(det: dict[str, Any]) -> tuple[int, int, int, int] | None:
+    bbox = det.get("bbox_xyxy")
+    if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+        return None
+
+    try:
+        x1, y1, x2, y2 = [int(round(float(v))) for v in bbox]
+    except (TypeError, ValueError):
+        return None
+
+    if x2 <= x1 or y2 <= y1:
+        return None
+
+    return x1, y1, x2, y2
+
+
+def _crop_jersey_region(image: np.ndarray, bbox: tuple[int, int, int, int]) -> np.ndarray:
+    height, width = image.shape[:2]
+    x1, y1, x2, y2 = bbox
+
+    x1 = max(0, min(width - 1, x1))
+    x2 = max(0, min(width, x2))
+    y1 = max(0, min(height - 1, y1))
+    y2 = max(0, min(height, y2))
+
+    box_w = max(1, x2 - x1)
+    box_h = max(1, y2 - y1)
+
+    # Focus on torso/jersey area:
+    # - avoid head/top noise,
+    # - avoid legs and grass,
+    # - use central part of bbox.
+    crop_x1 = x1 + int(0.20 * box_w)
+    crop_x2 = x2 - int(0.20 * box_w)
+    crop_y1 = y1 + int(0.20 * box_h)
+    crop_y2 = y1 + int(0.62 * box_h)
+
+    crop_x1 = max(0, min(width - 1, crop_x1))
+    crop_x2 = max(crop_x1 + 1, min(width, crop_x2))
+    crop_y1 = max(0, min(height - 1, crop_y1))
+    crop_y2 = max(crop_y1 + 1, min(height, crop_y2))
+
+    return image[crop_y1:crop_y2, crop_x1:crop_x2]
+
+
+def _estimate_jersey_color_bgr(crop: np.ndarray) -> np.ndarray | None:
+    if crop.size == 0:
+        return None
+
+    hsv = cv2.cvtColor(crop, cv2.COLOR_BGR2HSV)
+    h = hsv[..., 0]
+    s = hsv[..., 1]
+    v = hsv[..., 2]
+
+    # Remove grass-like pixels and very dark/gray pixels.
+    # OpenCV hue range is 0..179. Grass usually sits around 35..90.
+    grass_mask = (h >= 35) & (h <= 90) & (s >= 35)
+    informative_mask = (s >= 35) & (v >= 45) & (~grass_mask)
+
+    pixels = crop[informative_mask]
+    if len(pixels) < 8:
+        # Fallback: use non-green pixels with weaker constraints.
+        fallback_mask = (v >= 35) & (~grass_mask)
+        pixels = crop[fallback_mask]
+
+    if len(pixels) == 0:
+        return None
+
+    # Median is more stable than mean for small crops and compression artifacts.
+    return np.median(pixels.reshape(-1, 3), axis=0).astype(np.uint8)
+
+
+def _cluster_two_teams(player_items: list[tuple[int, np.ndarray]]) -> list[tuple[int, str, float]]:
+    if not player_items:
+        return []
+
+    if len(player_items) == 1:
+        idx, _ = player_items[0]
+        return [(idx, "team_a", 1.0)]
+
+    indexes = [idx for idx, _ in player_items]
+    colors_bgr = np.stack([color for _, color in player_items]).astype(np.float32)
+
+    # Use LAB because it is more color-distance friendly than raw BGR.
+    colors_lab = _bgr_array_to_lab(colors_bgr)
+
+    centers, assignments = _two_means(colors_lab)
+
+    counts = Counter(assignments.tolist())
+    if len(counts) < 2:
+        return [(idx, "unknown", 0.0) for idx in indexes]
+
+    # Stable naming: larger cluster = team_a, smaller cluster = team_b.
+    ordered_clusters = [cluster for cluster, _ in counts.most_common()]
+    cluster_to_team = {
+        ordered_clusters[0]: "team_a",
+        ordered_clusters[1]: "team_b",
+    }
+
+    output: list[tuple[int, str, float]] = []
+
+    for row_idx, det_idx in enumerate(indexes):
+        cluster = int(assignments[row_idx])
+        team = cluster_to_team.get(cluster, "unknown")
+
+        if team == "unknown":
+            output.append((det_idx, "unknown", 0.0))
+            continue
+
+        own_dist = float(np.linalg.norm(colors_lab[row_idx] - centers[cluster]))
+        other_cluster = 1 - cluster
+        other_dist = float(np.linalg.norm(colors_lab[row_idx] - centers[other_cluster]))
+
+        confidence = other_dist / (own_dist + other_dist + 1e-6)
+        confidence = max(0.0, min(1.0, confidence))
+
+        output.append((det_idx, team, confidence))
+
+    return output
+
+
+def _bgr_array_to_lab(colors_bgr: np.ndarray) -> np.ndarray:
+    colors = colors_bgr.reshape(-1, 1, 3).astype(np.uint8)
+    lab = cv2.cvtColor(colors, cv2.COLOR_BGR2LAB)
+    return lab.reshape(-1, 3).astype(np.float32)
+
+
+def _two_means(points: np.ndarray, iterations: int = 12) -> tuple[np.ndarray, np.ndarray]:
+    if len(points) < 2:
+        centers = np.vstack([points[0], points[0]])
+        assignments = np.zeros(len(points), dtype=np.int32)
+        return centers, assignments
+
+    # Deterministic initialization: farthest pair.
+    distances = np.linalg.norm(points[:, None, :] - points[None, :, :], axis=2)
+    first, second = np.unravel_index(np.argmax(distances), distances.shape)
+    centers = np.stack([points[first], points[second]]).astype(np.float32)
+
+    assignments = np.zeros(len(points), dtype=np.int32)
+    for _ in range(iterations):
+        dist_to_centers = np.linalg.norm(points[:, None, :] - centers[None, :, :], axis=2)
+        assignments = np.argmin(dist_to_centers, axis=1).astype(np.int32)
+
+        for cluster in (0, 1):
+            mask = assignments == cluster
+            if np.any(mask):
+                centers[cluster] = points[mask].mean(axis=0)
+
+    return centers, assignments
+
+
+def _smooth_by_track_id(detections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    votes: dict[int, Counter[str]] = defaultdict(Counter)
+
+    for det in detections:
+        track_id = det.get("track_id")
+        team = det.get("team")
+        if isinstance(track_id, int) and isinstance(team, str) and team.startswith("team_"):
+            votes[track_id][team] += 1
+
+    if not votes:
+        return detections
+
+    smoothed = [dict(det) for det in detections]
+    for det in smoothed:
+        track_id = det.get("track_id")
+        if not isinstance(track_id, int) or track_id not in votes:
+            continue
+        det["team_raw"] = det.get("team")
+        det["team"] = votes[track_id].most_common(1)[0][0]
+        det["team_smoothed"] = True
+
+    return smoothed
+
+
+def _build_minimap_entities(detections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    entities: list[dict[str, Any]] = []
+
+    for det in detections:
+        class_name = _normalize_class(det.get("class"))
+        if class_name not in PLAYER_CLASSES and class_name not in REFEREE_CLASSES:
+            continue
+
+        bbox = _read_bbox(det)
+        if bbox is None:
+            continue
+
+        x1, y1, x2, y2 = bbox
+        entity = {
+            "class": class_name,
+            "team": det.get("team", "unknown"),
+            "bbox_xyxy": [x1, y1, x2, y2],
+            "center_xy": [round((x1 + x2) / 2.0, 2), round((y1 + y2) / 2.0, 2)],
+            "confidence": det.get("confidence"),
+        }
+
+        if "track_id" in det:
+            entity["track_id"] = det["track_id"]
+        if "frame_index" in det:
+            entity["frame_index"] = det["frame_index"]
+
+        entities.append(entity)
+
+    return entities
+
+
+def team_color_bgr(team: str) -> tuple[int, int, int]:
+    colors = {
+        "team_a": (255, 80, 80),
+        "team_b": (80, 180, 255),
+        "referee": (80, 255, 255),
+        "unknown": (220, 220, 220),
+        "not_applicable": (0, 220, 255),
+    }
+    return colors.get(str(team), colors["unknown"])

--- a/src/murawa/vision/team_assignment.py
+++ b/src/murawa/vision/team_assignment.py
@@ -2,11 +2,20 @@ from __future__ import annotations
 
 from collections import Counter, defaultdict
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
-import cv2
 import numpy as np
+
+from murawa.vision.team_assignment_helpers import (
+    MIN_PLAYER_BOX_HEIGHT_PX,
+    MIN_PLAYER_BOX_WIDTH_PX,
+    MIN_PLAYER_CONFIDENCE,
+    cluster_players_by_jersey_color,
+    crop_jersey_region,
+    estimate_jersey_color_bgr,
+    normalize_class_name,
+    read_bbox_xyxy,
+)
 
 
 PLAYER_CLASSES = {"player", "goalkeeper"}
@@ -20,30 +29,16 @@ class TeamAssignmentResult:
     minimap_entities: list[dict[str, Any]]
 
 
-def assign_teams_to_frame(image_path: Path, detections: list[dict[str, Any]]) -> TeamAssignmentResult:
-    """Assign player detections to teams using jersey colors.
-
-    This is an MVP heuristic intended for post-processing model predictions.
-    It does not train any new model. It uses bbox crops, estimates jersey color,
-    clusters players into two teams, and keeps referee/unknown separately.
-    """
-    image = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
-    if image is None:
-        return TeamAssignmentResult(
-            detections=detections,
-            summary={
-                "enabled": False,
-                "reason": f"Could not read image: {image_path}",
-                "team_counts": {},
-            },
-            minimap_entities=[],
-        )
-
+def assign_teams_to_frame(
+    image_bgr: np.ndarray,
+    detections: list[dict[str, Any]],
+) -> TeamAssignmentResult:
+    """Assign player detections to teams using simple jersey-color clustering."""
     enriched = [dict(det) for det in detections]
-    player_items: list[tuple[int, np.ndarray]] = []
+    players_with_jersey_color: list[tuple[int, np.ndarray]] = []
 
-    for idx, det in enumerate(enriched):
-        class_name = _normalize_class(det.get("class"))
+    for det_idx, det in enumerate(enriched):
+        class_name = normalize_class_name(det.get("class"))
 
         if class_name in REFEREE_CLASSES:
             det["team"] = "referee"
@@ -51,53 +46,58 @@ def assign_teams_to_frame(image_path: Path, detections: list[dict[str, Any]]) ->
             continue
 
         if class_name not in PLAYER_CLASSES:
-            det["team"] = "not_applicable"
-            det["team_confidence"] = 1.0
             continue
 
-        bbox = _read_bbox(det)
+        bbox = read_bbox_xyxy(det)
         if bbox is None:
             det["team"] = "unknown"
             det["team_confidence"] = 0.0
             continue
 
         x1, y1, x2, y2 = bbox
-        box_w = x2 - x1
-        box_h = y2 - y1
+        box_width = x2 - x1
+        box_height = y2 - y1
         confidence = float(det.get("confidence", 0.0))
 
-        # Very small / low-confidence partial detections usually hurt color clustering.
-        if box_w < 15 or box_h < 35 or confidence < 0.45:
+        if (
+            box_width < MIN_PLAYER_BOX_WIDTH_PX
+            or box_height < MIN_PLAYER_BOX_HEIGHT_PX
+            or confidence < MIN_PLAYER_CONFIDENCE
+        ):
             det["team"] = "unknown"
             det["team_confidence"] = 0.0
             continue
 
-        jersey_crop = _crop_jersey_region(image, bbox)
-        color = _estimate_jersey_color_bgr(jersey_crop)
-        if color is None:
+        jersey_crop = crop_jersey_region(image_bgr, bbox)
+        jersey_color = estimate_jersey_color_bgr(jersey_crop)
+        if jersey_color is None:
             det["team"] = "unknown"
             det["team_confidence"] = 0.0
             continue
 
-        det["jersey_color_bgr"] = [int(v) for v in color.tolist()]
-        player_items.append((idx, color.astype(np.float32)))
+        det["jersey_color_bgr"] = [int(value) for value in jersey_color.tolist()]
+        players_with_jersey_color.append((det_idx, jersey_color.astype(np.float32)))
 
-    team_labels = _cluster_two_teams(player_items)
+    team_assignments = cluster_players_by_jersey_color(players_with_jersey_color)
 
-    for idx, label, confidence in team_labels:
-        enriched[idx]["team"] = label
-        enriched[idx]["team_confidence"] = round(float(confidence), 4)
+    for det_idx, team, confidence in team_assignments:
+        enriched[det_idx]["team"] = team
+        enriched[det_idx]["team_confidence"] = round(float(confidence), 4)
 
-    enriched = _smooth_by_track_id(enriched)
+    enriched = _smooth_team_by_track_id(enriched)
     minimap_entities = _build_minimap_entities(enriched)
 
-    team_counts = Counter(str(det.get("team", "unknown")) for det in enriched)
     summary = {
         "enabled": True,
         "method": "jersey_color_kmeans_mvp",
         "player_classes": sorted(PLAYER_CLASSES),
         "referee_classes": sorted(REFEREE_CLASSES),
-        "team_counts": dict(sorted(team_counts.items())),
+        "parameters": {
+            "min_player_box_width_px": MIN_PLAYER_BOX_WIDTH_PX,
+            "min_player_box_height_px": MIN_PLAYER_BOX_HEIGHT_PX,
+            "min_player_confidence": MIN_PLAYER_CONFIDENCE,
+        },
+        "team_counts": _count_player_teams(enriched),
         "minimap_entities": len(minimap_entities),
         "notes": [
             "Team assignment is heuristic and based on jersey color crops.",
@@ -113,194 +113,61 @@ def assign_teams_to_frame(image_path: Path, detections: list[dict[str, Any]]) ->
     )
 
 
-def _normalize_class(value: Any) -> str:
-    return str(value or "").strip().lower().replace("-", "_")
-
-
-def _read_bbox(det: dict[str, Any]) -> tuple[int, int, int, int] | None:
-    bbox = det.get("bbox_xyxy")
-    if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
-        return None
-
-    try:
-        x1, y1, x2, y2 = [int(round(float(v))) for v in bbox]
-    except (TypeError, ValueError):
-        return None
-
-    if x2 <= x1 or y2 <= y1:
-        return None
-
-    return x1, y1, x2, y2
-
-
-def _crop_jersey_region(image: np.ndarray, bbox: tuple[int, int, int, int]) -> np.ndarray:
-    height, width = image.shape[:2]
-    x1, y1, x2, y2 = bbox
-
-    x1 = max(0, min(width - 1, x1))
-    x2 = max(0, min(width, x2))
-    y1 = max(0, min(height - 1, y1))
-    y2 = max(0, min(height, y2))
-
-    box_w = max(1, x2 - x1)
-    box_h = max(1, y2 - y1)
-
-    # Focus on torso/jersey area:
-    # - avoid head/top noise,
-    # - avoid legs and grass,
-    # - use central part of bbox.
-    crop_x1 = x1 + int(0.20 * box_w)
-    crop_x2 = x2 - int(0.20 * box_w)
-    crop_y1 = y1 + int(0.20 * box_h)
-    crop_y2 = y1 + int(0.62 * box_h)
-
-    crop_x1 = max(0, min(width - 1, crop_x1))
-    crop_x2 = max(crop_x1 + 1, min(width, crop_x2))
-    crop_y1 = max(0, min(height - 1, crop_y1))
-    crop_y2 = max(crop_y1 + 1, min(height, crop_y2))
-
-    return image[crop_y1:crop_y2, crop_x1:crop_x2]
-
-
-def _estimate_jersey_color_bgr(crop: np.ndarray) -> np.ndarray | None:
-    if crop.size == 0:
-        return None
-
-    hsv = cv2.cvtColor(crop, cv2.COLOR_BGR2HSV)
-    h = hsv[..., 0]
-    s = hsv[..., 1]
-    v = hsv[..., 2]
-
-    # Remove grass-like pixels and very dark/gray pixels.
-    # OpenCV hue range is 0..179. Grass usually sits around 35..90.
-    grass_mask = (h >= 35) & (h <= 90) & (s >= 35)
-    informative_mask = (s >= 35) & (v >= 45) & (~grass_mask)
-
-    pixels = crop[informative_mask]
-    if len(pixels) < 8:
-        # Fallback: use non-green pixels with weaker constraints.
-        fallback_mask = (v >= 35) & (~grass_mask)
-        pixels = crop[fallback_mask]
-
-    if len(pixels) == 0:
-        return None
-
-    # Median is more stable than mean for small crops and compression artifacts.
-    return np.median(pixels.reshape(-1, 3), axis=0).astype(np.uint8)
-
-
-def _cluster_two_teams(player_items: list[tuple[int, np.ndarray]]) -> list[tuple[int, str, float]]:
-    if not player_items:
-        return []
-
-    if len(player_items) == 1:
-        idx, _ = player_items[0]
-        return [(idx, "team_a", 1.0)]
-
-    indexes = [idx for idx, _ in player_items]
-    colors_bgr = np.stack([color for _, color in player_items]).astype(np.float32)
-
-    # Use LAB because it is more color-distance friendly than raw BGR.
-    colors_lab = _bgr_array_to_lab(colors_bgr)
-
-    centers, assignments = _two_means(colors_lab)
-
-    counts = Counter(assignments.tolist())
-    if len(counts) < 2:
-        return [(idx, "unknown", 0.0) for idx in indexes]
-
-    # Stable naming: larger cluster = team_a, smaller cluster = team_b.
-    ordered_clusters = [cluster for cluster, _ in counts.most_common()]
-    cluster_to_team = {
-        ordered_clusters[0]: "team_a",
-        ordered_clusters[1]: "team_b",
-    }
-
-    output: list[tuple[int, str, float]] = []
-
-    for row_idx, det_idx in enumerate(indexes):
-        cluster = int(assignments[row_idx])
-        team = cluster_to_team.get(cluster, "unknown")
-
-        if team == "unknown":
-            output.append((det_idx, "unknown", 0.0))
-            continue
-
-        own_dist = float(np.linalg.norm(colors_lab[row_idx] - centers[cluster]))
-        other_cluster = 1 - cluster
-        other_dist = float(np.linalg.norm(colors_lab[row_idx] - centers[other_cluster]))
-
-        confidence = other_dist / (own_dist + other_dist + 1e-6)
-        confidence = max(0.0, min(1.0, confidence))
-
-        output.append((det_idx, team, confidence))
-
-    return output
-
-
-def _bgr_array_to_lab(colors_bgr: np.ndarray) -> np.ndarray:
-    colors = colors_bgr.reshape(-1, 1, 3).astype(np.uint8)
-    lab = cv2.cvtColor(colors, cv2.COLOR_BGR2LAB)
-    return lab.reshape(-1, 3).astype(np.float32)
-
-
-def _two_means(points: np.ndarray, iterations: int = 12) -> tuple[np.ndarray, np.ndarray]:
-    if len(points) < 2:
-        centers = np.vstack([points[0], points[0]])
-        assignments = np.zeros(len(points), dtype=np.int32)
-        return centers, assignments
-
-    # Deterministic initialization: farthest pair.
-    distances = np.linalg.norm(points[:, None, :] - points[None, :, :], axis=2)
-    first, second = np.unravel_index(np.argmax(distances), distances.shape)
-    centers = np.stack([points[first], points[second]]).astype(np.float32)
-
-    assignments = np.zeros(len(points), dtype=np.int32)
-    for _ in range(iterations):
-        dist_to_centers = np.linalg.norm(points[:, None, :] - centers[None, :, :], axis=2)
-        assignments = np.argmin(dist_to_centers, axis=1).astype(np.int32)
-
-        for cluster in (0, 1):
-            mask = assignments == cluster
-            if np.any(mask):
-                centers[cluster] = points[mask].mean(axis=0)
-
-    return centers, assignments
-
-
-def _smooth_by_track_id(detections: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    votes: dict[int, Counter[str]] = defaultdict(Counter)
+def _smooth_team_by_track_id(detections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    votes_by_track: dict[int, Counter[str]] = defaultdict(Counter)
 
     for det in detections:
         track_id = det.get("track_id")
         team = det.get("team")
         if isinstance(track_id, int) and isinstance(team, str) and team.startswith("team_"):
-            votes[track_id][team] += 1
+            votes_by_track[track_id][team] += 1
 
-    if not votes:
+    if not votes_by_track:
         return detections
 
     smoothed = [dict(det) for det in detections]
     for det in smoothed:
         track_id = det.get("track_id")
-        if not isinstance(track_id, int) or track_id not in votes:
+        if not isinstance(track_id, int) or track_id not in votes_by_track:
             continue
-        det["team_raw"] = det.get("team")
-        det["team"] = votes[track_id].most_common(1)[0][0]
-        det["team_smoothed"] = True
+
+        team_votes = votes_by_track[track_id]
+        final_team, final_votes = team_votes.most_common(1)[0]
+        total_votes = sum(team_votes.values())
+        previous_team = det.get("team")
+
+        if previous_team != final_team:
+            det["team_raw"] = previous_team
+            det["team_confidence_raw"] = det.get("team_confidence")
+            det["team_smoothed"] = True
+
+        det["team"] = final_team
+        det["team_confidence"] = round(final_votes / total_votes, 4)
 
     return smoothed
+
+
+def _count_player_teams(detections: list[dict[str, Any]]) -> dict[str, int]:
+    team_counts: Counter[str] = Counter()
+
+    for det in detections:
+        class_name = normalize_class_name(det.get("class"))
+        if class_name not in PLAYER_CLASSES and class_name not in REFEREE_CLASSES:
+            continue
+        team_counts[str(det.get("team", "unknown"))] += 1
+
+    return dict(sorted(team_counts.items()))
 
 
 def _build_minimap_entities(detections: list[dict[str, Any]]) -> list[dict[str, Any]]:
     entities: list[dict[str, Any]] = []
 
     for det in detections:
-        class_name = _normalize_class(det.get("class"))
+        class_name = normalize_class_name(det.get("class"))
         if class_name not in PLAYER_CLASSES and class_name not in REFEREE_CLASSES:
             continue
 
-        bbox = _read_bbox(det)
+        bbox = read_bbox_xyxy(det)
         if bbox is None:
             continue
 
@@ -321,14 +188,3 @@ def _build_minimap_entities(detections: list[dict[str, Any]]) -> list[dict[str, 
         entities.append(entity)
 
     return entities
-
-
-def team_color_bgr(team: str) -> tuple[int, int, int]:
-    colors = {
-        "team_a": (255, 80, 80),
-        "team_b": (80, 180, 255),
-        "referee": (80, 255, 255),
-        "unknown": (220, 220, 220),
-        "not_applicable": (0, 220, 255),
-    }
-    return colors.get(str(team), colors["unknown"])

--- a/src/murawa/vision/team_assignment_helpers.py
+++ b/src/murawa/vision/team_assignment_helpers.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+import cv2
+import numpy as np
+
+
+MIN_PLAYER_BOX_WIDTH_PX = 15
+MIN_PLAYER_BOX_HEIGHT_PX = 35
+MIN_PLAYER_CONFIDENCE = 0.45
+
+JERSEY_CROP_X_MARGIN_RATIO = 0.20
+JERSEY_CROP_Y_START_RATIO = 0.20
+JERSEY_CROP_Y_END_RATIO = 0.62
+
+GRASS_HUE_MIN = 35
+GRASS_HUE_MAX = 90
+MIN_GRASS_SATURATION = 35
+MIN_JERSEY_SATURATION = 35
+MIN_JERSEY_VALUE = 45
+MIN_FALLBACK_VALUE = 35
+MIN_INFORMATIVE_PIXELS = 8
+
+COLOR_CLUSTER_ITERATIONS = 12
+
+
+def normalize_class_name(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def read_bbox_xyxy(det: dict[str, Any]) -> tuple[int, int, int, int] | None:
+    bbox = det.get("bbox_xyxy")
+    if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+        return None
+
+    try:
+        x1, y1, x2, y2 = [int(round(float(value))) for value in bbox]
+    except (TypeError, ValueError):
+        return None
+
+    if x2 <= x1 or y2 <= y1:
+        return None
+
+    return x1, y1, x2, y2
+
+
+def crop_jersey_region(image_bgr: np.ndarray, bbox: tuple[int, int, int, int]) -> np.ndarray:
+    height, width = image_bgr.shape[:2]
+    x1, y1, x2, y2 = bbox
+
+    x1 = max(0, min(width - 1, x1))
+    x2 = max(0, min(width, x2))
+    y1 = max(0, min(height - 1, y1))
+    y2 = max(0, min(height, y2))
+
+    box_width = max(1, x2 - x1)
+    box_height = max(1, y2 - y1)
+
+    crop_x1 = x1 + int(JERSEY_CROP_X_MARGIN_RATIO * box_width)
+    crop_x2 = x2 - int(JERSEY_CROP_X_MARGIN_RATIO * box_width)
+    crop_y1 = y1 + int(JERSEY_CROP_Y_START_RATIO * box_height)
+    crop_y2 = y1 + int(JERSEY_CROP_Y_END_RATIO * box_height)
+
+    crop_x1 = max(0, min(width - 1, crop_x1))
+    crop_x2 = max(crop_x1 + 1, min(width, crop_x2))
+    crop_y1 = max(0, min(height - 1, crop_y1))
+    crop_y2 = max(crop_y1 + 1, min(height, crop_y2))
+
+    return image_bgr[crop_y1:crop_y2, crop_x1:crop_x2]
+
+
+def estimate_jersey_color_bgr(jersey_crop: np.ndarray) -> np.ndarray | None:
+    if jersey_crop.size == 0:
+        return None
+
+    hsv = cv2.cvtColor(jersey_crop, cv2.COLOR_BGR2HSV)
+    hue = hsv[..., 0]
+    saturation = hsv[..., 1]
+    value = hsv[..., 2]
+
+    grass_pixels = (
+        (hue >= GRASS_HUE_MIN)
+        & (hue <= GRASS_HUE_MAX)
+        & (saturation >= MIN_GRASS_SATURATION)
+    )
+    jersey_pixels = (
+        (saturation >= MIN_JERSEY_SATURATION)
+        & (value >= MIN_JERSEY_VALUE)
+        & (~grass_pixels)
+    )
+
+    pixels = jersey_crop[jersey_pixels]
+    if len(pixels) < MIN_INFORMATIVE_PIXELS:
+        pixels = jersey_crop[(value >= MIN_FALLBACK_VALUE) & (~grass_pixels)]
+
+    if len(pixels) == 0:
+        return None
+
+    return np.median(pixels.reshape(-1, 3), axis=0).astype(np.uint8)
+
+
+def cluster_players_by_jersey_color(
+    players_with_jersey_color: list[tuple[int, np.ndarray]],
+) -> list[tuple[int, str, float]]:
+    if not players_with_jersey_color:
+        return []
+
+    if len(players_with_jersey_color) == 1:
+        det_idx, _ = players_with_jersey_color[0]
+        return [(det_idx, "team_a", 1.0)]
+
+    indexes = [det_idx for det_idx, _ in players_with_jersey_color]
+    colors_bgr = np.stack([color for _, color in players_with_jersey_color]).astype(np.float32)
+    colors_lab = _bgr_array_to_lab(colors_bgr)
+
+    centers, color_groups = _cluster_two_color_groups(colors_lab)
+    counts = Counter(color_groups.tolist())
+    if len(counts) < 2:
+        return [(det_idx, "unknown", 0.0) for det_idx in indexes]
+
+    ordered_groups = [group for group, _ in counts.most_common()]
+    group_to_team = {
+        ordered_groups[0]: "team_a",
+        ordered_groups[1]: "team_b",
+    }
+
+    assignments: list[tuple[int, str, float]] = []
+    for row_idx, det_idx in enumerate(indexes):
+        group = int(color_groups[row_idx])
+        team = group_to_team.get(group, "unknown")
+        if team == "unknown":
+            assignments.append((det_idx, "unknown", 0.0))
+            continue
+
+        own_distance = float(np.linalg.norm(colors_lab[row_idx] - centers[group]))
+        other_group = 1 - group
+        other_distance = float(np.linalg.norm(colors_lab[row_idx] - centers[other_group]))
+        confidence = other_distance / (own_distance + other_distance + 1e-6)
+
+        assignments.append((det_idx, team, max(0.0, min(1.0, confidence))))
+
+    return assignments
+
+
+def team_preview_color_bgr(team: str) -> tuple[int, int, int]:
+    colors = {
+        "team_a": (255, 80, 80),
+        "team_b": (80, 180, 255),
+        "referee": (80, 255, 255),
+        "unknown": (220, 220, 220),
+    }
+    return colors.get(str(team), colors["unknown"])
+
+
+def _bgr_array_to_lab(colors_bgr: np.ndarray) -> np.ndarray:
+    colors = colors_bgr.reshape(-1, 1, 3).astype(np.uint8)
+    lab = cv2.cvtColor(colors, cv2.COLOR_BGR2LAB)
+    return lab.reshape(-1, 3).astype(np.float32)
+
+
+def _cluster_two_color_groups(points: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    if len(points) < 2:
+        centers = np.vstack([points[0], points[0]])
+        color_groups = np.zeros(len(points), dtype=np.int32)
+        return centers, color_groups
+
+    distances = np.linalg.norm(points[:, None, :] - points[None, :, :], axis=2)
+    first, second = np.unravel_index(np.argmax(distances), distances.shape)
+    centers = np.stack([points[first], points[second]]).astype(np.float32)
+
+    color_groups = np.zeros(len(points), dtype=np.int32)
+    for _ in range(COLOR_CLUSTER_ITERATIONS):
+        distance_to_centers = np.linalg.norm(points[:, None, :] - centers[None, :, :], axis=2)
+        color_groups = np.argmin(distance_to_centers, axis=1).astype(np.int32)
+
+        for group in (0, 1):
+            group_mask = color_groups == group
+            if np.any(group_mask):
+                centers[group] = points[group_mask].mean(axis=0)
+
+    return centers, color_groups


### PR DESCRIPTION
Ten PR realizuje issue #19 poprzez dodanie modułu przypisywania zawodników do drużyn po etapie detekcji.

Celem było przygotowanie prostej warstwy logicznej, która wzbogaca surowy wynik predykcji o informacje potrzebne do dalszej wizualizacji, w szczególności pod przyszły moduł minimapy.

---

## Zakres zmian

Ten PR dodaje:

- moduł `src/murawa/vision/team_assignment.py`
- funkcję przypisywania zawodników do drużyn na podstawie koloru stroju
- wycinanie fragmentu zawodnika z bboxa i analizę koloru koszulki
- dopisywanie pola `team` do detekcji
- osobne traktowanie klasy `referee`, jeśli model ją wykryje
- strukturę `minimap_entities` gotową pod dalszą wizualizację
- podpięcie team assignment do pipeline’u analizy pojedynczej klatki
- kolorowanie bboxów w preview według przypisanej drużyny

---

## Jak działa przypisywanie drużyn

Po wykonaniu predykcji modelu pipeline przekazuje listę detekcji do modułu team assignment.

Dla każdej detekcji klasy:

- `player`
- `goalkeeper`

moduł:

1. odczytuje `bbox_xyxy`,
2. wycina z obrazu centralną część bboxa odpowiadającą mniej więcej koszulce,
3. usuwa piksele przypominające murawę,
4. estymuje reprezentatywny kolor stroju,
5. grupuje zawodników na dwie drużyny metodą prostego, deterministycznego klastrowania kolorów,
6. dopisuje do detekcji:
   - `team`
   - `team_confidence`
   - `jersey_color_bgr`

Dla detekcji klasy `referee` moduł nie próbuje zgadywać drużyny kolorem, tylko przypisuje:
"team": "referee"

## Dane dopisywane do wyniku
Po analizie wynik prediction_summary.json zawiera dodatkowo:
"team_assignment": {
  "enabled": true,
  "method": "jersey_color_kmeans_mvp",
  "team_counts": {
    "team_a": 10,
    "team_b": 10,
    "referee": 2
  },
  "minimap_entities": 22
}

Każda detekcja zawodnika dostaje także informację o drużynie:

{
  "class": "player",
  "bbox_xyxy": [...],
  "team": "team_a",
  "team_confidence": 0.82
}

## Struktura pod minimapę

PR dodaje także listę:
"minimap_entities": [...]

Każdy element zawiera:
-class
-team
-bbox_xyxy
-center_xy
-confidence
-opcjonalnie track_id
-opcjonalnie frame_index
Dzięki temu kolejny moduł minimapy nie musi ponownie interpretować surowych detekcji, tylko może korzystać z uporządkowanych danych.

## Preview

Preview klatki zostało rozszerzone o kolorowanie bboxów według przypisania:
team_a
team_b
referee
unknown
Dzięki temu można szybko wizualnie ocenić, czy przypisanie drużyn działa sensownie na danej klatce.

## Ograniczenia MVP

To rozwiązanie jest celowo prostym MVP opartym na heurystyce koloru stroju.
Może być niestabilne w sytuacjach takich jak:
-bardzo małe bboxy,
-zasłonięci zawodnicy,
-cienie,
-podobne kolory strojów,
-białe lub mało nasycone stroje,
-błędne albo zdublowane detekcje modelu.

Nie jest to docelowy klasyfikator drużyn, tylko lekka warstwa postprocessingu po predykcji, zgodna z zakresem issue.

## Test
Test wykonano np na klatce meczu Barca–Atleti i psg-bayern przy użyciu modelu rfdetr-ready-base.

Wynik barca-atleti:
status: ok
total_detections: 22
player: 20
referee: 2
team_a: 10
team_b: 10
referee: 2
minimap_entities: 22

Każda detekcja zawodnika dostaje także informację o drużynie:

"minimap_entities": [
    {
      "class": "player",
      "team": "team_a",
      "bbox_xyxy": [
        477,
        713,
        518,
        812
      ],
      "center_xy": [
        497.5,
        762.5
      ],
      "confidence": 0.8815011978149414
    }, I TAK DALEJ

barca-atleti
<img width="1919" height="1079" alt="frame_preview" src="https://github.com/user-attachments/assets/3fb64258-a5c7-4ae4-ae79-674c97f10e69" />

psg-bayern
<img width="1919" height="1079" alt="frame_preview" src="https://github.com/user-attachments/assets/b20daf98-d108-448a-ba62-a36be73dc2ff" />
