### PR TITLE
feat: introduce video analysys

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This creates:
 python scripts/predict.py --model yolo --dataset-variant base --mode frame
 
 # match-style analysis
-python scripts/predict.py --model yolo --dataset-variant base --mode match --input-path /path/to/match.mp4
+python scripts/predict.py --model yolo --dataset-variant base --mode match --input-path /path/to/match.mp4 --sample-fps 3
 ```
 
 Note: `mode=match` requires a video input. If no fallback video is found in `data/ready/<variant>/test`, pass `--input-path`.
@@ -165,6 +165,8 @@ Outputs are written to:
 - `outputs/predictions/<run_name>/prediction_summary.json`
 - `outputs/predictions/<run_name>/*_prediction.txt`
 - `outputs/predictions/<run_name>/preview/*.jpg` (mini preview frames/images)
+- `outputs/predictions/<run_name>/<analysis_id>/...` for match-video summaries and detection payloads
+- `outputs/videos/*.webm` for browser-ready match-analysis videos generated from uploaded or CLI video clips
 
 ### Use internet APP by streamlit GUI
 

--- a/app/pages/analyses_page.py
+++ b/app/pages/analyses_page.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import streamlit as st
+
+from murawa.services.saved_match_analyses import SavedMatchAnalysis, list_saved_match_analyses
+from ui_common import PREVIEW_MEDIA_WIDTH, ROOT, show_counts, video_mime_type
+
+
+def render() -> None:
+    st.subheader("Przeglądaj analizy")
+
+    analyses = list_saved_match_analyses(project_root=ROOT)
+    if not analyses:
+        st.info("Brak zapisanych analiz meczowych w `outputs/videos`.")
+        return
+
+    table_state = st.dataframe(
+        _analysis_rows(analyses),
+        hide_index=True,
+        height="content",
+        on_select="rerun",
+        selection_mode="single-row-required",
+        key="saved_match_analyses",
+    )
+    selected_rows = table_state.selection.rows
+    selected_index = selected_rows[0] if selected_rows else 0
+    _show_analysis(_selected_analysis(analyses, selected_index))
+
+
+def _show_analysis(analysis: SavedMatchAnalysis) -> None:
+    if analysis.video_path.exists():
+        st.video(
+            str(analysis.video_path),
+            format=video_mime_type(analysis.video_path),
+            width=PREVIEW_MEDIA_WIDTH,
+        )
+    else:
+        st.warning("Wideo wynikowe nie jest już dostępne na dysku.")
+
+    actions = st.columns([1, 2])
+    with actions[0]:
+        if analysis.video_path.exists():
+            st.download_button(
+                "Pobierz wynik",
+                data=analysis.video_path.read_bytes(),
+                file_name=analysis.video_path.name,
+                mime=video_mime_type(analysis.video_path),
+                key=f"download_{analysis.analysis_id}_{analysis.video_path.suffix}",
+            )
+    with actions[1]:
+        st.caption(f"ID analizy: `{analysis.analysis_id}`")
+        st.caption(f"Zapisano: `{analysis.video_path}`")
+
+    if analysis.summary is None:
+        st.info("Metadane tej analizy nie są dostępne.")
+        return
+
+    _show_summary(analysis.summary)
+
+
+def _show_summary(summary: dict[str, Any]) -> None:
+    model = _string_value(summary.get("model"))
+    run_name = _string_value(summary.get("resolved_run_name"))
+    st.caption(f"Model: `{model}` | Run: `{run_name}`")
+
+    metadata = _mapping(summary.get("video_metadata"))
+    stats = _mapping(summary.get("stats"))
+    metrics = st.columns(4)
+    metrics[0].metric("Długość klipu", _duration_value(metadata.get("duration_seconds")))
+    metrics[1].metric("Próbkowanie", _fps_value(summary.get("sample_fps")))
+    metrics[2].metric("Klatki analizy", _count_value(summary.get("sampled_frames")))
+    metrics[3].metric("Detekcje", _count_value(stats.get("total_detections")))
+
+    details = st.columns(2)
+    with details[0]:
+        show_counts("Klasy detekcji", stats.get("classes"), "Klasa")
+    with details[1]:
+        show_counts("Drużyny", stats.get("team_counts"), "Etykieta")
+
+
+def _analysis_rows(analyses: list[SavedMatchAnalysis]) -> list[dict[str, str]]:
+    return [_analysis_row(analysis) for analysis in analyses]
+
+
+def _selected_analysis(
+    analyses: list[SavedMatchAnalysis],
+    selected_index: int,
+) -> SavedMatchAnalysis:
+    if 0 <= selected_index < len(analyses):
+        return analyses[selected_index]
+    return analyses[0]
+
+
+def _analysis_row(analysis: SavedMatchAnalysis) -> dict[str, str]:
+    summary = analysis.summary or {}
+    metadata = _mapping(summary.get("video_metadata"))
+    stats = _mapping(summary.get("stats"))
+    return {
+        "Wideo": analysis.video_path.name,
+        "Zapisane": _modified_at_value(analysis.modified_at_ns),
+        "Model": _string_value(summary.get("model")),
+        "Run": _string_value(summary.get("resolved_run_name")),
+        "Długość": _duration_value(metadata.get("duration_seconds")),
+        "Klatki": _count_value(summary.get("sampled_frames")),
+        "Detekcje": _count_value(stats.get("total_detections")),
+    }
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _string_value(value: object) -> str:
+    if isinstance(value, str) and value:
+        return value
+    return "Brak danych"
+
+
+def _duration_value(value: object) -> str:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"{float(value):.1f} s"
+    return "Brak danych"
+
+
+def _fps_value(value: object) -> str:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"{value} FPS"
+    return "Brak danych"
+
+
+def _count_value(value: object) -> str:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(int(value))
+    return "Brak danych"
+
+
+def _modified_at_value(modified_at_ns: int) -> str:
+    return datetime.fromtimestamp(modified_at_ns / 1_000_000_000).strftime("%Y-%m-%d %H:%M")

--- a/app/pages/frame_page.py
+++ b/app/pages/frame_page.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
 from murawa.services.pipeline import analyze_frame_run
-from ui_common import ROOT, format_run_label, save_upload, show_result, trained_runs
+from ui_common import ROOT, format_run_label, show_result, temporary_upload_path, trained_runs
 
 
 def render() -> None:
@@ -30,11 +30,12 @@ def render() -> None:
     )
 
     if st.button("Uruchom analizę klatki", key="run_frame"):
-        st.session_state["frame_last_result"] = analyze_frame_run(
-            project_root=ROOT,
-            run_name=selected_run.run_name,
-            input_path=save_upload(uploaded),
-        )
+        with temporary_upload_path(uploaded) as upload_path:
+            st.session_state["frame_last_result"] = analyze_frame_run(
+                project_root=ROOT,
+                run_name=selected_run.run_name,
+                input_path=upload_path,
+            )
 
     result = st.session_state.get("frame_last_result")
     if isinstance(result, dict):

--- a/app/pages/match_page.py
+++ b/app/pages/match_page.py
@@ -1,7 +1,25 @@
+from pathlib import Path
+
 import streamlit as st
 
 from murawa.services.pipeline import analyze_match_run
-from ui_common import ROOT, format_run_label, save_upload, show_result, trained_runs
+from ui_common import (
+    PREVIEW_MEDIA_WIDTH,
+    ROOT,
+    format_run_label,
+    show_counts,
+    temporary_upload_path,
+    trained_runs,
+    video_mime_type,
+)
+
+PROGRESS_RANGES = {
+    "validate": (0.0, 0.08),
+    "extract": (0.08, 0.25),
+    "inference": (0.33, 0.45),
+    "render": (0.78, 0.20),
+    "save": (0.98, 0.02),
+}
 
 
 def render() -> None:
@@ -21,18 +39,102 @@ def render() -> None:
         key="match_run_name",
     )
     uploaded = st.file_uploader(
-        "Wgraj nagranie meczu (opcjonalnie)",
-        type=["mp4", "avi", "mov", "mkv"],
+        "Wgraj klip meczu",
+        type=["mp4", "avi", "mov", "mkv", "webm"],
         key="match_upload",
     )
+    sample_fps = st.slider(
+        "Klatki analizowane na sekundę",
+        min_value=1,
+        max_value=24,
+        value=3,
+        key="match_sample_fps",
+    )
+    st.caption("Obsługiwane są klipy demo do 60 sekund.")
 
-    if st.button("Uruchom analizę meczu", key="run_match"):
-        result = analyze_match_run(
-            project_root=ROOT,
-            run_name=selected_run.run_name,
-            input_path=save_upload(uploaded),
+    run_clicked = st.button(
+        "Uruchom analizę meczu",
+        key="run_match",
+        disabled=uploaded is None,
+        type="primary",
+    )
+    if run_clicked:
+        progress_bar = st.progress(0.0)
+        status_line = st.empty()
+
+        def on_progress(stage: str, progress: float, message: str) -> None:
+            start, width = PROGRESS_RANGES.get(stage, (0.0, 1.0))
+            progress_bar.progress(min(1.0, start + width * progress))
+            status_line.caption(message)
+
+        with temporary_upload_path(uploaded) as upload_path:
+            st.session_state["match_last_result"] = analyze_match_run(
+                project_root=ROOT,
+                run_name=selected_run.run_name,
+                input_path=upload_path,
+                sample_fps=sample_fps,
+                progress_callback=on_progress,
+            )
+
+    result = st.session_state.get("match_last_result")
+    if isinstance(result, dict):
+        _show_match_result(result)
+
+
+def _show_match_result(result: dict) -> None:
+    if result.get("status") == "missing_run":
+        st.info(result.get("message", "Nie znaleziono wybranego runu."))
+        return
+    if result.get("status") != "ok":
+        st.error(result.get("message", "Analiza klipu zakończyła się błędem."))
+        return
+
+    video_path = Path(result.get("video_path", ""))
+    st.success("Analiza klipu zakończona.")
+
+    metadata = result.get("video_metadata", {})
+    stats = result.get("stats", {})
+    duration = float(metadata.get("duration_seconds", 0.0))
+    input_fps = float(metadata.get("fps", 0.0))
+    width = int(metadata.get("width", 0))
+    height = int(metadata.get("height", 0))
+
+    metrics = st.columns(4)
+    metrics[0].metric("Długość klipu", f"{duration:.1f} s")
+    metrics[1].metric("Próbkowanie", f"{result.get('sample_fps', 0)} FPS")
+    metrics[2].metric("Klatki analizy", str(result.get("sampled_frames", 0)))
+    metrics[3].metric("Detekcje", str(stats.get("total_detections", 0)))
+
+    if video_path.exists():
+        st.video(
+            str(video_path),
+            format=video_mime_type(video_path),
+            width=PREVIEW_MEDIA_WIDTH,
         )
-        show_result(result)
+        actions = st.columns([1, 2])
+        with actions[0]:
+            st.download_button(
+                "Pobierz wynik",
+                data=video_path.read_bytes(),
+                file_name=video_path.name,
+                mime=video_mime_type(video_path),
+            )
+        with actions[1]:
+            st.caption(f"Zapisano: `{video_path}`")
+    else:
+        st.warning("Wideo wynikowe nie jest już dostępne na dysku.")
+
+    details = st.columns(3)
+    with details[0]:
+        st.markdown("**Klip wejściowy**")
+        st.caption(
+            f"{width} x {height} px | {input_fps:.2f} FPS | "
+            f"{int(metadata.get('frame_count', 0))} klatek"
+        )
+    with details[1]:
+        show_counts("Klasy detekcji", stats.get("classes", {}), "Klasa")
+    with details[2]:
+        show_counts("Drużyny", stats.get("team_counts", {}), "Etykieta")
 
 
 if __name__ == "__main__":

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -11,19 +11,20 @@ if str(APP_DIR) not in sys.path:
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
+from pages.analyses_page import render as render_analyses_page
 from pages.data_page import render as render_data_page
 from pages.frame_page import render as render_frame_page
 from pages.match_page import render as render_match_page
 
 
 def main() -> None:
-    st.set_page_config(page_title="Murawa MVP", layout="centered")
-    st.title("Murawa MVP")
-    st.caption("Szkielet integracyjny: upload -> dummy pipeline -> wynik")
+    st.set_page_config(page_title="Murawa", layout="wide")
+    st.title("Murawa")
+    st.caption("Analiza klatek i klipów meczowych.")
 
     selected_view = st.sidebar.radio(
         "Widok",
-        options=["Analizuj klatkę", "Analizuj mecz", "Przegląd danych"],
+        options=["Analizuj klatkę", "Analizuj mecz", "Przeglądaj analizy", "Przegląd danych"],
     )
 
     if selected_view == "Analizuj klatkę":
@@ -31,6 +32,9 @@ def main() -> None:
         return
     if selected_view == "Analizuj mecz":
         render_match_page()
+        return
+    if selected_view == "Przeglądaj analizy":
+        render_analyses_page()
         return
 
     render_data_page()

--- a/app/ui_common.py
+++ b/app/ui_common.py
@@ -1,12 +1,14 @@
+from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from datetime import datetime
 
 import streamlit as st
 
 from murawa.services.artifacts import TrainedRunRecord, list_available_runs
 
 ROOT = Path(__file__).resolve().parents[1]
+PREVIEW_MEDIA_WIDTH = 960
 
 
 def dataset_variants() -> list[str]:
@@ -37,14 +39,35 @@ def format_run_label(run: TrainedRunRecord) -> str:
     return f"{run.model} | {run.dataset_variant} | {created_at}"
 
 
-def save_upload(uploaded_file) -> str | None:
+@contextmanager
+def temporary_upload_path(uploaded_file):
     if uploaded_file is None:
-        return None
+        yield None
+        return
 
     suffix = Path(uploaded_file.name).suffix or ".bin"
     with NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
         tmp.write(uploaded_file.getbuffer())
-        return tmp.name
+        path = tmp.name
+
+    try:
+        yield path
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def show_counts(title: str, counts: object, key_label: str) -> None:
+    st.markdown(f"**{title}**")
+    if not isinstance(counts, dict) or not counts:
+        st.caption("Brak danych.")
+        return
+    st.table([{key_label: key, "Liczba": value} for key, value in sorted(counts.items())])
+
+
+def video_mime_type(video_path: Path) -> str:
+    if video_path.suffix.lower() == ".webm":
+        return "video/webm"
+    return "video/mp4"
 
 
 def show_result(result: dict, show_debug_assets: bool = False) -> None:
@@ -67,7 +90,7 @@ def show_result(result: dict, show_debug_assets: bool = False) -> None:
     for asset in preview_assets[:3]:
         preview_file = Path(asset)
         if preview_file.exists():
-            st.image(str(preview_file), caption=preview_file.name, use_container_width=True)
+            st.image(str(preview_file), caption=preview_file.name, width=PREVIEW_MEDIA_WIDTH)
 
     if not show_debug_assets:
         return
@@ -76,4 +99,4 @@ def show_result(result: dict, show_debug_assets: bool = False) -> None:
     for asset in debug_assets[:3]:
         debug_file = Path(asset)
         if debug_file.exists():
-            st.image(str(debug_file), caption=debug_file.name, use_container_width=True)
+            st.image(str(debug_file), caption=debug_file.name, width=PREVIEW_MEDIA_WIDTH)

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -23,6 +23,12 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Optional input path: image for mode=frame, video for mode=match.",
     )
+    p.add_argument(
+        "--sample-fps",
+        type=int,
+        default=3,
+        help="Frame sampling rate for mode=match. Expected range: 1-24.",
+    )
     return p.parse_args()
 
 
@@ -42,6 +48,7 @@ def main() -> int:
             model=args.model,
             dataset_variant=args.dataset_variant,
             input_path=args.input_path,
+            sample_fps=args.sample_fps,
         )
 
     if result["status"] != "ok":
@@ -54,6 +61,8 @@ def main() -> int:
     logger.info("detections=%s", result.get("stats", {}).get("total_detections", 0))
     logger.info("preview_assets=%s", len(result.get("preview_assets", [])))
     logger.info("debug_preview_assets=%s", len(result.get("debug_preview_assets", [])))
+    if result.get("video_path"):
+        logger.info("video=%s", result["video_path"])
 
     print(
         json.dumps(
@@ -66,6 +75,9 @@ def main() -> int:
                 "summary_path": result["summary_path"],
                 "preview_assets": result.get("preview_assets", []),
                 "debug_preview_assets": result.get("debug_preview_assets", []),
+                "video_path": result.get("video_path", ""),
+                "sample_fps": result.get("sample_fps"),
+                "sampled_frames": result.get("sampled_frames"),
                 "stats": result.get("stats", {}),
             },
             indent=2,

--- a/src/murawa/models/rfdetr.py
+++ b/src/murawa/models/rfdetr.py
@@ -1,9 +1,9 @@
+from collections.abc import Callable
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 import csv
 from dataclasses import dataclass
 import json
 import logging
-import math
 from pathlib import Path
 import random
 import shutil
@@ -189,83 +189,58 @@ class RfDetrAdapter:
         checkpoint_path: Path,
         mode: str,
     ) -> list[dict]:
-        supported_modes = {"frame", "match"}
-        if mode not in supported_modes:
-            raise ValueError(f"Unsupported mode='{mode}'. Expected one of: {sorted(supported_modes)}.")
+        if mode != "frame":
+            raise ValueError("RfDetrAdapter.predict supports only mode='frame'.")
 
-        input_path = input_path.resolve()
+        frame_batches = self.predict_frames(
+            frame_paths=[input_path],
+            checkpoint_path=checkpoint_path,
+        )
+        return frame_batches[0]
+
+    def predict_frames(
+        self,
+        frame_paths: list[Path],
+        *,
+        checkpoint_path: Path,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> list[list[dict]]:
         checkpoint_path = checkpoint_path.resolve()
-        if not input_path.exists() or not input_path.is_file():
-            raise FileNotFoundError(f"Prediction input does not exist or is not a file: {input_path}")
         if not checkpoint_path.exists() or not checkpoint_path.is_file():
             raise FileNotFoundError(f"RF-DETR checkpoint does not exist: {checkpoint_path}")
 
-        variant = _resolve_prediction_variant(checkpoint_path=checkpoint_path)
-        rfdetr_cls = _import_rfdetr(variant)
-        try:
-            model = rfdetr_cls(pretrain_weights=str(checkpoint_path))
-        except Exception as exc:
-            raise RuntimeError(
-                f"RF-DETR backend failed to load checkpoint '{checkpoint_path}' "
-                f"for variant='{variant}': {exc}"
-            ) from exc
+        model = _load_prediction_model(checkpoint_path=checkpoint_path)
 
         class_mapping = _load_class_mapping(checkpoint_path=checkpoint_path)
         detection_confidence = _resolve_detection_confidence(checkpoint_path=checkpoint_path)
-        if mode == "frame":
-            if input_path.suffix.lower() not in IMAGE_SUFFIXES:
+        frame_batches: list[list[dict]] = []
+        total_frames = len(frame_paths)
+
+        for frame_number, frame_path in enumerate(frame_paths, start=1):
+            resolved_frame = frame_path.resolve()
+            if resolved_frame.suffix.lower() not in IMAGE_SUFFIXES:
                 raise ValueError(
-                    f"Frame mode requires an image file. Received suffix='{input_path.suffix}'."
+                    f"RF-DETR sampled frame requires an image file. Received: {resolved_frame}"
                 )
-            frame_rgb = _read_frame_image_rgb(input_path)
-            detections = _predict_image(model=model, image=frame_rgb, threshold=detection_confidence)
-            return _convert_detections_to_frame_schema(detections, class_mapping)
+            if not resolved_frame.exists() or not resolved_frame.is_file():
+                raise FileNotFoundError(
+                    f"RF-DETR sampled frame does not exist: {resolved_frame}"
+                )
 
-        if input_path.suffix.lower() not in VIDEO_SUFFIXES:
-            raise ValueError(
-                f"Match mode requires a video file. Received suffix='{input_path.suffix}', "
-                f"expected one of {sorted(VIDEO_SUFFIXES)}."
+            frame_rgb = _read_frame_image_rgb(resolved_frame)
+            detections = _predict_image(
+                model=model,
+                image=frame_rgb,
+                threshold=detection_confidence,
             )
+            frame_batches.append(_convert_detections_to_frame_schema(detections, class_mapping))
+            if progress_callback is not None:
+                progress_callback(frame_number, total_frames)
 
-        cap = cv2.VideoCapture(str(input_path))
-        if not cap.isOpened():
-            raise RuntimeError(f"Could not open video input for RF-DETR prediction: {input_path}")
-
-        frame_step = 5
-        frame_index = -1
-        frame_batches: list[tuple[int, list[dict]]] = []
-        try:
-            while True:
-                ok, frame_bgr = cap.read()
-                if not ok:
-                    break
-                frame_index += 1
-                if frame_index % frame_step != 0:
-                    continue
-
-                frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
-                try:
-                    detections = _predict_image(
-                        model=model,
-                        image=frame_rgb,
-                        threshold=detection_confidence,
-                    )
-                except Exception as exc:
-                    raise RuntimeError(
-                        f"RF-DETR match prediction failed at frame_index={frame_index}: {exc}"
-                    ) from exc
-
-                frame_batches.append(
-                    (frame_index, _convert_detections_to_frame_schema(detections, class_mapping))
-                )
-        finally:
-            cap.release()
-
-        return _to_match_schema(frame_batches=frame_batches, max_distance_px=55.0)
+        return frame_batches
 
 
 IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp"}
-VIDEO_SUFFIXES = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
 METRICS_CSV_NAMES = ("metrics.csv", "results.csv")
 RFDETR_RESOLUTION_BLOCK = 32
 RFDETR_DEFAULT_RESOLUTIONS = {
@@ -781,6 +756,18 @@ def _find_metrics_csv(backend_dir: Path) -> Path | None:
     return candidates[0]
 
 
+def _load_prediction_model(checkpoint_path: Path):
+    variant = _resolve_prediction_variant(checkpoint_path=checkpoint_path)
+    rfdetr_cls = _import_rfdetr(variant)
+    try:
+        return rfdetr_cls(pretrain_weights=str(checkpoint_path))
+    except Exception as exc:
+        raise RuntimeError(
+            f"RF-DETR backend failed to load checkpoint '{checkpoint_path}' "
+            f"for variant='{variant}': {exc}"
+        ) from exc
+
+
 def _predict_image(model, image: Any, threshold: float):
     try:
         detections = model.predict(image, threshold=threshold)
@@ -819,50 +806,6 @@ def _convert_detections_to_frame_schema(detections: Any, class_mapping: dict[int
             }
         )
     return payload
-
-
-def _to_match_schema(frame_batches: list[tuple[int, list[dict]]], max_distance_px: float) -> list[dict]:
-    active_tracks: dict[str, list[tuple[int, tuple[float, float]]]] = {}
-    next_track_id = 1
-    output: list[dict] = []
-
-    for frame_index, detections in frame_batches:
-        new_tracks: dict[str, list[tuple[int, tuple[float, float]]]] = {}
-        used_track_ids: set[int] = set()
-        for det in detections:
-            x1, y1, x2, y2 = det["bbox_xyxy"]
-            center = ((x1 + x2) / 2.0, (y1 + y2) / 2.0)
-            class_name = det["class"]
-            assigned_track_id = None
-            best_distance = None
-
-            for track_id, previous_center in active_tracks.get(class_name, []):
-                if track_id in used_track_ids:
-                    continue
-                distance = math.dist(center, previous_center)
-                if distance > max_distance_px:
-                    continue
-                if best_distance is None or distance < best_distance:
-                    best_distance = distance
-                    assigned_track_id = track_id
-
-            if assigned_track_id is None:
-                assigned_track_id = next_track_id
-                next_track_id += 1
-
-            used_track_ids.add(assigned_track_id)
-            new_tracks.setdefault(class_name, []).append((assigned_track_id, center))
-            output.append(
-                {
-                    "frame_index": frame_index,
-                    "class": class_name,
-                    "confidence": float(det["confidence"]),
-                    "track_id": assigned_track_id,
-                }
-            )
-        active_tracks = new_tracks
-
-    return output
 
 
 def _load_class_mapping(checkpoint_path: Path) -> dict[int, str]:

--- a/src/murawa/models/yolo.py
+++ b/src/murawa/models/yolo.py
@@ -1,14 +1,13 @@
-from dataclasses import dataclass
 import csv
+from collections.abc import Callable
+from dataclasses import dataclass
 import importlib
 import importlib.util
-import math
 from pathlib import Path
 import random
 import shutil
 from typing import Any
 
-import cv2
 import yaml
 
 from murawa.data import DataLoaderError, LoadedSplit, load_training_split
@@ -159,14 +158,23 @@ class YoloAdapter:
         checkpoint_path: Path,
         mode: str,
     ) -> list[dict]:
-        supported_modes = {"frame", "match"}
-        if mode not in supported_modes:
-            raise ValueError(f"Unsupported mode='{mode}'. Expected one of: {sorted(supported_modes)}.")
+        if mode != "frame":
+            raise ValueError("YoloAdapter.predict supports only mode='frame'.")
 
-        input_path = input_path.resolve()
+        frame_batches = self.predict_frames(
+            frame_paths=[input_path],
+            checkpoint_path=checkpoint_path,
+        )
+        return frame_batches[0]
+
+    def predict_frames(
+        self,
+        frame_paths: list[Path],
+        *,
+        checkpoint_path: Path,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> list[list[dict]]:
         checkpoint_path = checkpoint_path.resolve()
-        if not input_path.exists() or not input_path.is_file():
-            raise FileNotFoundError(f"Prediction input does not exist: {input_path}")
         if not checkpoint_path.exists() or not checkpoint_path.is_file():
             raise FileNotFoundError(f"YOLO checkpoint does not exist: {checkpoint_path}")
 
@@ -174,76 +182,42 @@ class YoloAdapter:
         try:
             model = yolo_cls(str(checkpoint_path))
         except Exception as exc:
-            raise RuntimeError(f"YOLO backend failed to load checkpoint '{checkpoint_path}': {exc}") from exc
+            raise RuntimeError(
+                f"YOLO backend failed to load checkpoint '{checkpoint_path}': {exc}"
+            ) from exc
 
         detection_confidence = _resolve_detection_confidence(checkpoint_path=checkpoint_path)
+        frame_batches: list[list[dict]] = []
+        total_frames = len(frame_paths)
 
-        if mode == "frame":
+        for frame_number, frame_path in enumerate(frame_paths, start=1):
+            resolved_frame = frame_path.resolve()
+            if resolved_frame.suffix.lower() not in IMAGE_SUFFIXES:
+                raise ValueError(
+                    f"YOLO sampled frame requires an image file. Received: {resolved_frame}"
+                )
+            if not resolved_frame.exists() or not resolved_frame.is_file():
+                raise FileNotFoundError(f"YOLO sampled frame does not exist: {resolved_frame}")
+
             try:
                 results = model.predict(
-                    source=str(input_path),
+                    source=str(resolved_frame),
                     conf=detection_confidence,
                     verbose=False,
                 )
             except Exception as exc:
-                raise RuntimeError(f"YOLO frame prediction failed: {exc}") from exc
-            return _convert_results_to_frame_schema(results)
+                raise RuntimeError(
+                    f"YOLO sampled-frame prediction failed for '{resolved_frame.name}': {exc}"
+                ) from exc
 
-        # match mode (MVP): frame-by-frame inference with lightweight deterministic track ids.
-        if input_path.suffix.lower() in IMAGE_SUFFIXES:
-            try:
-                results = model.predict(
-                    source=str(input_path),
-                    conf=detection_confidence,
-                    verbose=False,
-                )
-            except Exception as exc:
-                raise RuntimeError(f"YOLO match prediction failed for image input: {exc}") from exc
-            frame_detections = _extract_frame_detections(results)
-            return _to_match_schema(frame_batches=[(0, frame_detections)], max_distance_px=55.0)
+            frame_batches.append(_convert_results_to_frame_schema(results))
+            if progress_callback is not None:
+                progress_callback(frame_number, total_frames)
 
-        if input_path.suffix.lower() not in VIDEO_SUFFIXES:
-            raise ValueError(
-                f"Unsupported file suffix '{input_path.suffix}' for mode='match'. "
-                f"Expected image ({sorted(IMAGE_SUFFIXES)}) or video ({sorted(VIDEO_SUFFIXES)})."
-            )
-
-        cap = cv2.VideoCapture(str(input_path))
-        if not cap.isOpened():
-            raise RuntimeError(f"Could not open video input for YOLO prediction: {input_path}")
-
-        frame_step = 5
-        frame_index = -1
-        frame_batches: list[tuple[int, list[dict]]] = []
-        try:
-            while True:
-                ok, frame = cap.read()
-                if not ok:
-                    break
-                frame_index += 1
-                if frame_index % frame_step != 0:
-                    continue
-                try:
-                    batch_results = model.predict(
-                        source=frame,
-                        conf=detection_confidence,
-                        verbose=False,
-                    )
-                except Exception as exc:
-                    raise RuntimeError(
-                        f"YOLO match prediction failed at frame_index={frame_index}: {exc}"
-                    ) from exc
-
-                detections = _extract_frame_detections(batch_results)
-                frame_batches.append((frame_index, detections))
-        finally:
-            cap.release()
-
-        return _to_match_schema(frame_batches=frame_batches, max_distance_px=55.0)
+        return frame_batches
 
 
 IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp"}
-VIDEO_SUFFIXES = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
 TRAIN_LOSS_COLUMNS = ("train/box_loss", "train/cls_loss", "train/dfl_loss")
 VAL_LOSS_COLUMNS = ("val/box_loss", "val/cls_loss", "val/dfl_loss")
 MAP50_COLUMNS = ("metrics/mAP50(B)", "metrics/mAP50-95(B)")
@@ -524,53 +498,6 @@ def _extract_frame_detections(results: Any) -> list[dict]:
                 }
             )
     return payload
-
-
-def _to_match_schema(frame_batches: list[tuple[int, list[dict]]], max_distance_px: float) -> list[dict]:
-    active_tracks: dict[str, list[tuple[int, tuple[float, float]]]] = {}
-    next_track_id = 1
-    output: list[dict] = []
-
-    for frame_index, detections in frame_batches:
-        new_tracks: dict[str, list[tuple[int, tuple[float, float]]]] = {}
-        used_track_ids: set[int] = set()
-
-        for det in detections:
-            x1, y1, x2, y2 = det["bbox_xyxy"]
-            center = ((x1 + x2) / 2.0, (y1 + y2) / 2.0)
-            class_name = det["class"]
-
-            assigned_track_id = None
-            candidates = active_tracks.get(class_name, [])
-            best_distance = None
-            for track_id, previous_center in candidates:
-                if track_id in used_track_ids:
-                    continue
-                distance = math.dist(center, previous_center)
-                if distance > max_distance_px:
-                    continue
-                if best_distance is None or distance < best_distance:
-                    best_distance = distance
-                    assigned_track_id = track_id
-
-            if assigned_track_id is None:
-                assigned_track_id = next_track_id
-                next_track_id += 1
-
-            used_track_ids.add(assigned_track_id)
-            new_tracks.setdefault(class_name, []).append((assigned_track_id, center))
-            output.append(
-                {
-                    "frame_index": frame_index,
-                    "class": class_name,
-                    "confidence": float(det["confidence"]),
-                    "track_id": assigned_track_id,
-                }
-            )
-
-        active_tracks = new_tracks
-
-    return output
 
 
 def _import_ultralytics_yolo():

--- a/src/murawa/services/pipeline.py
+++ b/src/murawa/services/pipeline.py
@@ -1,4 +1,7 @@
+from datetime import datetime, timezone
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from uuid import uuid4
 
 import cv2
 import numpy as np
@@ -6,7 +9,16 @@ import numpy as np
 from murawa.data.path_resolver import IMAGE_SUFFIXES, PREDICTIONS_ROOT, VIDEO_SUFFIXES, pick_input
 from murawa.models import build_training_adapter, normalize_model_name
 from murawa.services.artifacts import latest_run, resolve_run, write_json
-from murawa.vision.team_assignment import PLAYER_CLASSES, REFEREE_CLASSES, assign_teams_to_frame
+from murawa.services.video_processing import (
+    DEFAULT_SAMPLE_FPS,
+    ProgressCallback,
+    SampledFrame,
+    VideoProcessingError,
+    extract_sampled_frames,
+    validate_sample_fps,
+    validate_video_input,
+)
+from murawa.vision.team_assignment import assign_teams_to_frame, count_player_teams
 from murawa.vision.team_assignment_helpers import (
     crop_jersey_region,
     normalize_class_name,
@@ -22,21 +34,53 @@ def analyze_frame(
 
 
 def analyze_match(
-    project_root: Path, model: str, dataset_variant: str, input_path: str | None = None
+    project_root: Path,
+    model: str,
+    dataset_variant: str,
+    input_path: str | None = None,
+    sample_fps: int = DEFAULT_SAMPLE_FPS,
+    progress_callback: ProgressCallback | None = None,
 ) -> dict:
-    return _run_analysis(project_root, model, dataset_variant, mode="match", input_path=input_path)
+    return _run_analysis(
+        project_root,
+        model,
+        dataset_variant,
+        mode="match",
+        input_path=input_path,
+        sample_fps=sample_fps,
+        progress_callback=progress_callback,
+    )
 
 
 def analyze_frame_run(project_root: Path, run_name: str, input_path: str | None = None) -> dict:
     return _run_analysis_for_run(project_root, run_name, mode="frame", input_path=input_path)
 
 
-def analyze_match_run(project_root: Path, run_name: str, input_path: str | None = None) -> dict:
-    return _run_analysis_for_run(project_root, run_name, mode="match", input_path=input_path)
+def analyze_match_run(
+    project_root: Path,
+    run_name: str,
+    input_path: str | None = None,
+    sample_fps: int = DEFAULT_SAMPLE_FPS,
+    progress_callback: ProgressCallback | None = None,
+) -> dict:
+    return _run_analysis_for_run(
+        project_root,
+        run_name,
+        mode="match",
+        input_path=input_path,
+        sample_fps=sample_fps,
+        progress_callback=progress_callback,
+    )
 
 
 def _run_analysis(
-    project_root: Path, model: str, dataset_variant: str, mode: str, input_path: str | None
+    project_root: Path,
+    model: str,
+    dataset_variant: str,
+    mode: str,
+    input_path: str | None,
+    sample_fps: int = DEFAULT_SAMPLE_FPS,
+    progress_callback: ProgressCallback | None = None,
 ) -> dict:
     normalized_model = normalize_model_name(model)
     base_payload = _make_base_payload(mode=mode, model=normalized_model, dataset_variant=dataset_variant)
@@ -56,6 +100,8 @@ def _run_analysis(
         run_name=run_name,
         mode=mode,
         input_path=input_path,
+        sample_fps=sample_fps,
+        progress_callback=progress_callback,
         fallback_payload=base_payload,
     )
 
@@ -65,6 +111,8 @@ def _run_analysis_for_run(
     run_name: str,
     mode: str,
     input_path: str | None,
+    sample_fps: int = DEFAULT_SAMPLE_FPS,
+    progress_callback: ProgressCallback | None = None,
     fallback_payload: dict | None = None,
 ) -> dict:
     try:
@@ -87,6 +135,18 @@ def _run_analysis_for_run(
     )
     base_payload["resolved_run_name"] = run.run_name
 
+    if mode == "match":
+        return _run_match_video_analysis(
+            project_root=project_root,
+            run=run,
+            normalized_model=normalized_model,
+            dataset_variant=dataset_variant,
+            input_path=input_path,
+            sample_fps=sample_fps,
+            progress_callback=progress_callback,
+            base_payload=base_payload,
+        )
+
     out_dir = project_root / PREDICTIONS_ROOT / run.run_name
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -94,11 +154,10 @@ def _run_analysis_for_run(
     checkpoint_path = run.checkpoint_path
 
     if not input_found:
-        expected = "image" if mode == "frame" else "video"
         base_payload["status"] = "error"
         base_payload["resolved_input"] = resolved_input
         base_payload["message"] = (
-            f"Could not find a valid input file ({expected}) for {normalized_model}. "
+            f"Could not find a valid image input file for {normalized_model}. "
             "Provide --input-path or ensure the file exists in the test directory."
         )
         return base_payload
@@ -115,7 +174,7 @@ def _run_analysis_for_run(
         return base_payload
 
     suffix = resolved_path.suffix.lower()
-    if mode == "frame" and suffix not in IMAGE_SUFFIXES:
+    if suffix not in IMAGE_SUFFIXES:
         base_payload["status"] = "error"
         base_payload["resolved_input"] = resolved_input
         base_payload["message"] = (
@@ -124,30 +183,19 @@ def _run_analysis_for_run(
         )
         return base_payload
 
-    if mode == "match" and suffix not in VIDEO_SUFFIXES:
+    frame_image_bgr = cv2.imread(str(resolved_path), cv2.IMREAD_COLOR)
+    if frame_image_bgr is None:
         base_payload["status"] = "error"
         base_payload["resolved_input"] = resolved_input
-        base_payload["message"] = (
-            f"Match mode requires a video file. Received suffix='{suffix}', "
-            f"expected one of {sorted(VIDEO_SUFFIXES)}."
-        )
+        base_payload["message"] = f"Could not read frame image: {resolved_input}"
         return base_payload
-
-    frame_image_bgr = None
-    if mode == "frame":
-        frame_image_bgr = cv2.imread(str(resolved_path), cv2.IMREAD_COLOR)
-        if frame_image_bgr is None:
-            base_payload["status"] = "error"
-            base_payload["resolved_input"] = resolved_input
-            base_payload["message"] = f"Could not read frame image: {resolved_input}"
-            return base_payload
 
     try:
         model_instance = build_training_adapter(normalized_model)
         detections = model_instance.predict(
             input_path=resolved_path,
             checkpoint_path=checkpoint_path,
-            mode=mode,
+            mode="frame",
         )
     except Exception as exc:
         base_payload["status"] = "error"
@@ -158,39 +206,27 @@ def _run_analysis_for_run(
     summary_path = out_dir / "prediction_summary.json"
     preview_path = out_dir / f"{mode}_prediction.txt"
 
-    team_assignment = {
-        "enabled": False,
-        "reason": "Team assignment is available only for frame image inputs in this MVP.",
-    }
-    minimap_entities: list[dict] = []
+    assignment_result = assign_teams_to_frame(
+        image_bgr=frame_image_bgr,
+        detections=detections,
+    )
+    detections = assignment_result.detections
+    team_assignment = assignment_result.summary
+    minimap_entities = assignment_result.minimap_entities
 
-    if mode == "frame" and frame_image_bgr is not None:
-        assignment_result = assign_teams_to_frame(
-            image_bgr=frame_image_bgr,
-            detections=detections,
-        )
-        detections = assignment_result.detections
-        team_assignment = assignment_result.summary
-        minimap_entities = assignment_result.minimap_entities
-
-    stats = _build_detection_stats(detections=detections, mode=mode)
-    preview_assets: list[str] = []
-    debug_preview_assets: list[str] = []
+    stats = _build_detection_stats(detections=detections)
 
     preview_assets = _write_preview_assets(
-        input_path=resolved_path,
         detections=detections,
-        mode=mode,
         out_dir=out_dir,
         team_assignment=team_assignment,
-        frame_image_bgr=frame_image_bgr.copy() if frame_image_bgr is not None else None,
+        frame_image_bgr=frame_image_bgr.copy(),
     )
-    if mode == "frame" and frame_image_bgr is not None:
-        debug_preview_assets = _write_team_assignment_debug_preview(
-            frame_image_bgr=frame_image_bgr,
-            detections=detections,
-            out_dir=out_dir,
-        )
+    debug_preview_assets = _write_team_assignment_debug_preview(
+        frame_image_bgr=frame_image_bgr,
+        detections=detections,
+        out_dir=out_dir,
+    )
 
     payload = {
         "status": "ok",
@@ -234,6 +270,276 @@ def _run_analysis_for_run(
     return payload
 
 
+def _run_match_video_analysis(
+    *,
+    project_root: Path,
+    run,
+    normalized_model: str,
+    dataset_variant: str,
+    input_path: str | None,
+    sample_fps: int,
+    progress_callback: ProgressCallback | None,
+    base_payload: dict,
+) -> dict:
+    base_payload["sample_fps"] = sample_fps
+    resolved_input, input_found = _resolve_input(project_root, "match", dataset_variant, input_path)
+    base_payload["resolved_input"] = resolved_input
+    base_payload["input_found"] = input_found
+
+    if not input_found:
+        base_payload["status"] = "error"
+        base_payload["message"] = (
+            "Could not find a valid video input. Upload a video file or pass --input-path."
+        )
+        return base_payload
+
+    resolved_path = Path(resolved_input)
+    try:
+        parsed_sample_fps = validate_sample_fps(sample_fps)
+        _emit_progress(
+            progress_callback,
+            "validate",
+            0.0,
+            "Validating video input.",
+        )
+        metadata = validate_video_input(resolved_path, allowed_suffixes=VIDEO_SUFFIXES)
+        _emit_progress(
+            progress_callback,
+            "validate",
+            1.0,
+            "Video input is ready.",
+        )
+    except VideoProcessingError as exc:
+        base_payload["status"] = "error"
+        base_payload["message"] = str(exc)
+        return base_payload
+
+    analysis_id = _make_match_analysis_id()
+    out_dir = project_root / PREDICTIONS_ROOT / run.run_name / analysis_id
+    videos_dir = project_root / "outputs" / "videos"
+    summary_path = out_dir / "prediction_summary.json"
+    preview_path = out_dir / "match_prediction.txt"
+    video_path = videos_dir / f"{analysis_id}.webm"
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    videos_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with TemporaryDirectory(prefix="murawa-match-") as temp_dir:
+            sampled_frames = extract_sampled_frames(
+                resolved_path,
+                output_dir=Path(temp_dir) / "frames",
+                metadata=metadata,
+                sample_fps=parsed_sample_fps,
+                progress_callback=progress_callback,
+            )
+
+            model_instance = build_training_adapter(normalized_model)
+            frame_batches = model_instance.predict_frames(
+                frame_paths=[frame.path for frame in sampled_frames],
+                checkpoint_path=run.checkpoint_path,
+                progress_callback=lambda completed, total: _emit_inference_progress(
+                    progress_callback=progress_callback,
+                    completed=completed,
+                    total=total,
+                ),
+            )
+            if len(frame_batches) != len(sampled_frames):
+                raise RuntimeError(
+                    "Prediction backend returned a different number of frame batches "
+                    f"({len(frame_batches)}) than sampled frames ({len(sampled_frames)})."
+                )
+
+            detections = _write_annotated_match_video(
+                video_path=video_path,
+                sampled_frames=sampled_frames,
+                frame_batches=frame_batches,
+                sample_fps=parsed_sample_fps,
+                progress_callback=progress_callback,
+            )
+    except Exception as exc:
+        video_path.unlink(missing_ok=True)
+        base_payload["status"] = "error"
+        base_payload["output_dir"] = str(out_dir)
+        base_payload["video_path"] = str(video_path)
+        base_payload["message"] = f"Match video analysis failed: {exc}"
+        return base_payload
+
+    stats = _build_detection_stats(detections=detections)
+    stats["sampled_frames"] = len(sampled_frames)
+    stats["team_counts"] = count_player_teams(detections)
+
+    payload = {
+        "status": "ok",
+        "mode": "match",
+        "model": normalized_model,
+        "dataset_variant": dataset_variant,
+        "resolved_run_name": run.run_name,
+        "analysis_id": analysis_id,
+        "checkpoint_path": str(run.checkpoint_path),
+        "metadata_path": str(run.metadata_dir),
+        "resolved_input": resolved_input,
+        "input_found": input_found,
+        "output_dir": str(out_dir),
+        "summary_path": str(summary_path),
+        "preview_path": str(preview_path),
+        "preview_assets": [],
+        "debug_preview_assets": [],
+        "video_path": str(video_path),
+        "video_metadata": metadata.as_dict(),
+        "sample_fps": parsed_sample_fps,
+        "sampled_frames": len(sampled_frames),
+        "sampled_frame_timeline": [_sampled_frame_timeline_item(frame) for frame in sampled_frames],
+        "stats": stats,
+        "team_assignment": {
+            "enabled": True,
+            "method": "jersey_color_kmeans_mvp_per_sampled_frame",
+            "team_counts": stats["team_counts"],
+        },
+        "minimap_entities": [],
+        "detections": detections,
+    }
+    write_json(summary_path, payload)
+    preview_path.write_text(
+        "\n".join(
+            [
+                "mode=match",
+                f"model={normalized_model}",
+                f"dataset_variant={dataset_variant}",
+                f"resolved_input={resolved_input}",
+                f"sample_fps={parsed_sample_fps}",
+                f"sampled_frames={len(sampled_frames)}",
+                f"detections={stats.get('total_detections', 0)}",
+                f"video_path={video_path}",
+                "Sampled-frame video analysis output.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _emit_progress(
+        progress_callback,
+        "save",
+        1.0,
+        "Saved video analysis output.",
+    )
+    return payload
+
+
+def _write_annotated_match_video(
+    *,
+    video_path: Path,
+    sampled_frames: list[SampledFrame],
+    frame_batches: list[list[dict]],
+    sample_fps: int,
+    progress_callback: ProgressCallback | None,
+) -> list[dict]:
+    writer = None
+    frame_size: tuple[int, int] | None = None
+    all_detections: list[dict] = []
+
+    try:
+        for render_index, (sampled_frame, frame_detections) in enumerate(
+            zip(sampled_frames, frame_batches, strict=True),
+            start=1,
+        ):
+            frame_image_bgr = cv2.imread(str(sampled_frame.path), cv2.IMREAD_COLOR)
+            if frame_image_bgr is None:
+                raise RuntimeError(f"Could not read sampled frame: {sampled_frame.path}")
+
+            height, width = frame_image_bgr.shape[:2]
+            if writer is None:
+                frame_size = (width, height)
+                writer = cv2.VideoWriter(
+                    str(video_path),
+                    cv2.VideoWriter_fourcc(*"VP80"),
+                    float(sample_fps),
+                    frame_size,
+                )
+                if not writer.isOpened():
+                    raise RuntimeError(f"Could not create output video: {video_path}")
+            elif frame_size is not None and frame_size != (width, height):
+                frame_image_bgr = cv2.resize(frame_image_bgr, frame_size)
+
+            timeline_detections = [
+                _add_sample_timeline(detection, sampled_frame) for detection in frame_detections
+            ]
+            assignment_result = assign_teams_to_frame(
+                image_bgr=frame_image_bgr,
+                detections=timeline_detections,
+            )
+            _draw_frame_overlay(
+                frame_image_bgr=frame_image_bgr,
+                detections=assignment_result.detections,
+                team_assignment=assignment_result.summary,
+                status_text=(
+                    f"t={sampled_frame.timestamp_seconds:.2f}s "
+                    f"source_frame={sampled_frame.source_frame_index}"
+                ),
+            )
+            writer.write(frame_image_bgr)
+            all_detections.extend(assignment_result.detections)
+            _emit_progress(
+                progress_callback,
+                "render",
+                render_index / max(1, len(sampled_frames)),
+                f"Rendering output video ({render_index}/{len(sampled_frames)} frames).",
+            )
+    finally:
+        if writer is not None:
+            writer.release()
+
+    if not video_path.exists() or video_path.stat().st_size <= 0:
+        raise RuntimeError(f"Output video was not written: {video_path}")
+    return all_detections
+
+
+def _add_sample_timeline(detection: dict, sampled_frame: SampledFrame) -> dict:
+    enriched = dict(detection)
+    enriched["sample_index"] = sampled_frame.sample_index
+    enriched["frame_index"] = sampled_frame.source_frame_index
+    enriched["timestamp_seconds"] = round(sampled_frame.timestamp_seconds, 4)
+    return enriched
+
+
+def _sampled_frame_timeline_item(sampled_frame: SampledFrame) -> dict:
+    return {
+        "sample_index": sampled_frame.sample_index,
+        "source_frame_index": sampled_frame.source_frame_index,
+        "timestamp_seconds": round(sampled_frame.timestamp_seconds, 4),
+    }
+
+
+def _make_match_analysis_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return f"match_{timestamp}_{uuid4().hex[:8]}"
+
+
+def _emit_inference_progress(
+    *,
+    progress_callback: ProgressCallback | None,
+    completed: int,
+    total: int,
+) -> None:
+    _emit_progress(
+        progress_callback,
+        "inference",
+        completed / max(1, total),
+        f"Running model inference ({completed}/{total} frames).",
+    )
+
+
+def _emit_progress(
+    progress_callback: ProgressCallback | None,
+    stage: str,
+    progress: float,
+    message: str,
+) -> None:
+    if progress_callback is None:
+        return
+    progress_callback(stage, min(1.0, max(0.0, progress)), message)
+
+
 def _make_base_payload(mode: str, model: str, dataset_variant: str) -> dict:
     return {
         "status": "error",
@@ -247,12 +553,18 @@ def _make_base_payload(mode: str, model: str, dataset_variant: str) -> dict:
         "preview_path": "",
         "preview_assets": [],
         "debug_preview_assets": [],
+        "video_path": "",
+        "video_metadata": {},
+        "sample_fps": DEFAULT_SAMPLE_FPS,
+        "sampled_frames": 0,
         "stats": {},
+        "team_assignment": {},
+        "minimap_entities": [],
         "detections": [],
     }
 
 
-def _build_detection_stats(detections: list[dict], mode: str) -> dict:
+def _build_detection_stats(detections: list[dict]) -> dict:
     by_class: dict[str, int] = {}
     confidences: list[float] = []
 
@@ -264,56 +576,31 @@ def _build_detection_stats(detections: list[dict], mode: str) -> dict:
         if isinstance(confidence, (int, float)):
             confidences.append(float(confidence))
 
-    stats = {
+    return {
         "total_detections": len(detections),
         "classes": by_class,
         "mean_confidence": (sum(confidences) / len(confidences)) if confidences else 0.0,
     }
 
-    if mode == "match":
-        frame_indexes = {
-            int(detection["frame_index"])
-            for detection in detections
-            if isinstance(detection.get("frame_index"), int)
-        }
-        track_ids = {
-            int(detection["track_id"])
-            for detection in detections
-            if isinstance(detection.get("track_id"), int)
-        }
-        stats["frames_with_detections"] = len(frame_indexes)
-        stats["unique_track_ids"] = len(track_ids)
-
-    return stats
-
 
 def _write_preview_assets(
-    input_path: Path,
     detections: list[dict],
-    mode: str,
     out_dir: Path,
-    team_assignment: dict | None = None,
-    frame_image_bgr: np.ndarray | None = None,
+    team_assignment: dict,
+    frame_image_bgr: np.ndarray,
 ) -> list[str]:
     preview_dir = out_dir / "preview"
     preview_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        if mode == "frame":
-            if frame_image_bgr is None:
-                return []
-            return _write_frame_preview(
-                frame_image_bgr=frame_image_bgr,
-                detections=detections,
-                preview_dir=preview_dir,
-                team_assignment=team_assignment or {},
-            )
-        if mode == "match":
-            return _write_match_preview(input_path=input_path, detections=detections, preview_dir=preview_dir)
+        return _write_frame_preview(
+            frame_image_bgr=frame_image_bgr,
+            detections=detections,
+            preview_dir=preview_dir,
+            team_assignment=team_assignment,
+        )
     except Exception:
         return []
-
-    return []
 
 
 def _write_frame_preview(
@@ -322,6 +609,26 @@ def _write_frame_preview(
     preview_dir: Path,
     team_assignment: dict,
 ) -> list[str]:
+    _draw_frame_overlay(
+        frame_image_bgr=frame_image_bgr,
+        detections=detections,
+        team_assignment=team_assignment,
+    )
+
+    preview_path = preview_dir / "frame_preview.jpg"
+    if not cv2.imwrite(str(preview_path), frame_image_bgr):
+        return []
+
+    return [str(preview_path)]
+
+
+def _draw_frame_overlay(
+    *,
+    frame_image_bgr: np.ndarray,
+    detections: list[dict],
+    team_assignment: dict,
+    status_text: str = "",
+) -> None:
     for detection in detections:
         bbox = read_bbox_xyxy(detection)
         if bbox is None:
@@ -365,11 +672,17 @@ def _write_frame_preview(
         2,
     )
 
-    preview_path = preview_dir / "frame_preview.jpg"
-    if not cv2.imwrite(str(preview_path), frame_image_bgr):
-        return []
-
-    return [str(preview_path)]
+    if status_text:
+        image_height = frame_image_bgr.shape[0]
+        cv2.putText(
+            frame_image_bgr,
+            status_text,
+            (10, max(28, image_height - 14)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.55,
+            (255, 255, 255),
+            2,
+        )
 
 
 def _draw_team_legend(
@@ -543,62 +856,6 @@ def _read_color_bgr(value: object) -> tuple[int, int, int] | None:
         return tuple(int(channel) for channel in value)
     except (TypeError, ValueError):
         return None
-
-
-def _write_match_preview(input_path: Path, detections: list[dict], preview_dir: Path) -> list[str]:
-    suffix = input_path.suffix.lower()
-    if suffix not in VIDEO_SUFFIXES:
-        return []
-
-    frame_counts: dict[int, int] = {}
-    for detection in detections:
-        frame_index = detection.get("frame_index")
-        if isinstance(frame_index, int):
-            frame_counts[frame_index] = frame_counts.get(frame_index, 0) + 1
-
-    target_frames = sorted(frame_counts.keys())[:3]
-    if not target_frames:
-        target_frames = [0]
-
-    cap = cv2.VideoCapture(str(input_path))
-    if not cap.isOpened():
-        return []
-
-    assets: list[str] = []
-    wanted = set(target_frames)
-    max_frame = max(target_frames)
-    frame_index = -1
-
-    try:
-        while wanted:
-            ok, frame = cap.read()
-            if not ok:
-                break
-
-            frame_index += 1
-            if frame_index not in wanted:
-                if frame_index > max_frame:
-                    break
-                continue
-
-            count = frame_counts.get(frame_index, 0)
-            cv2.putText(
-                frame,
-                f"frame={frame_index} detections={count}",
-                (10, 22),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.6,
-                (255, 255, 255),
-                2,
-            )
-            out_path = preview_dir / f"match_preview_{frame_index:06d}.jpg"
-            if cv2.imwrite(str(out_path), frame):
-                assets.append(str(out_path))
-            wanted.remove(frame_index)
-    finally:
-        cap.release()
-
-    return assets
 
 
 def _resolve_input(

--- a/src/murawa/services/saved_match_analyses.py
+++ b/src/murawa/services/saved_match_analyses.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MATCH_VIDEO_SUFFIXES = {".mp4", ".webm"}
+
+
+@dataclass(frozen=True)
+class SavedMatchAnalysis:
+    analysis_id: str
+    video_path: Path
+    modified_at_ns: int
+    summary_path: Path | None
+    summary: dict[str, Any] | None
+
+
+def list_saved_match_analyses(project_root: Path) -> list[SavedMatchAnalysis]:
+    videos_dir = project_root / "outputs" / "videos"
+    predictions_dir = project_root / "outputs" / "predictions"
+    if not videos_dir.exists() or not videos_dir.is_dir():
+        return []
+
+    saved_analyses: list[SavedMatchAnalysis] = []
+    for video_path in videos_dir.iterdir():
+        if not _is_match_video(video_path):
+            continue
+
+        try:
+            modified_at_ns = video_path.stat().st_mtime_ns
+        except OSError:
+            continue
+
+        summary_path = _find_summary_path(predictions_dir, analysis_id=video_path.stem)
+        saved_analyses.append(
+            SavedMatchAnalysis(
+                analysis_id=video_path.stem,
+                video_path=video_path,
+                modified_at_ns=modified_at_ns,
+                summary_path=summary_path,
+                summary=_load_summary(summary_path),
+            )
+        )
+
+    return sorted(
+        saved_analyses,
+        key=lambda analysis: (analysis.modified_at_ns, analysis.video_path.name),
+        reverse=True,
+    )
+
+
+def _is_match_video(path: Path) -> bool:
+    return path.is_file() and path.suffix.lower() in MATCH_VIDEO_SUFFIXES
+
+
+def _find_summary_path(predictions_dir: Path, *, analysis_id: str) -> Path | None:
+    if not predictions_dir.exists() or not predictions_dir.is_dir():
+        return None
+
+    for run_dir in sorted(predictions_dir.iterdir(), key=lambda path: path.name):
+        if not run_dir.is_dir():
+            continue
+        candidate = run_dir / analysis_id / "prediction_summary.json"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_summary(summary_path: Path | None) -> dict[str, Any] | None:
+    if summary_path is None:
+        return None
+
+    try:
+        payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    return payload

--- a/src/murawa/services/video_processing.py
+++ b/src/murawa/services/video_processing.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+
+MIN_SAMPLE_FPS = 1
+MAX_SAMPLE_FPS = 24
+DEFAULT_SAMPLE_FPS = 3
+MAX_VIDEO_DURATION_SECONDS = 60.0
+
+ProgressCallback = Callable[[str, float, str], None]
+
+
+class VideoProcessingError(RuntimeError):
+    """Raised when uploaded video input cannot be prepared for analysis."""
+
+
+@dataclass(frozen=True)
+class VideoMetadata:
+    fps: float
+    frame_count: int
+    width: int
+    height: int
+    duration_seconds: float
+
+    def as_dict(self) -> dict:
+        return {
+            "fps": round(self.fps, 4),
+            "frame_count": self.frame_count,
+            "width": self.width,
+            "height": self.height,
+            "duration_seconds": round(self.duration_seconds, 4),
+        }
+
+
+@dataclass(frozen=True)
+class SampledFrame:
+    sample_index: int
+    source_frame_index: int
+    timestamp_seconds: float
+    path: Path
+
+
+def validate_sample_fps(sample_fps: int) -> int:
+    if isinstance(sample_fps, bool):
+        raise VideoProcessingError(
+            f"Frame sampling rate must be an integer from {MIN_SAMPLE_FPS} to {MAX_SAMPLE_FPS} FPS."
+        )
+
+    try:
+        parsed = int(sample_fps)
+    except (TypeError, ValueError) as exc:
+        message = (
+            f"Frame sampling rate must be an integer from {MIN_SAMPLE_FPS} "
+            f"to {MAX_SAMPLE_FPS} FPS."
+        )
+        raise VideoProcessingError(message) from exc
+
+    if parsed < MIN_SAMPLE_FPS or parsed > MAX_SAMPLE_FPS:
+        raise VideoProcessingError(
+            f"Frame sampling rate must be between {MIN_SAMPLE_FPS} and {MAX_SAMPLE_FPS} FPS."
+        )
+    return parsed
+
+
+def validate_video_input(
+    input_path: Path,
+    *,
+    allowed_suffixes: set[str],
+    max_duration_seconds: float = MAX_VIDEO_DURATION_SECONDS,
+) -> VideoMetadata:
+    resolved = input_path.resolve()
+    if not resolved.exists() or not resolved.is_file():
+        raise VideoProcessingError(f"Video input must point to an existing file: {resolved}")
+
+    suffix = resolved.suffix.lower()
+    if suffix not in allowed_suffixes:
+        raise VideoProcessingError(
+            f"Video input suffix '{suffix}' is not supported. "
+            f"Expected one of {sorted(allowed_suffixes)}."
+        )
+
+    if resolved.stat().st_size <= 0:
+        raise VideoProcessingError("Uploaded video file is empty.")
+
+    cap = cv2.VideoCapture(str(resolved))
+    if not cap.isOpened():
+        raise VideoProcessingError("Uploaded video could not be opened by OpenCV.")
+
+    try:
+        fps = float(cap.get(cv2.CAP_PROP_FPS))
+        frame_count = int(round(cap.get(cv2.CAP_PROP_FRAME_COUNT)))
+        width = int(round(cap.get(cv2.CAP_PROP_FRAME_WIDTH)))
+        height = int(round(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)))
+        ok, first_frame = cap.read()
+    finally:
+        cap.release()
+
+    if not ok or first_frame is None or first_frame.size == 0:
+        raise VideoProcessingError("Uploaded video is not decodable into frames.")
+
+    if fps <= 0:
+        raise VideoProcessingError("Uploaded video has invalid FPS metadata.")
+    if frame_count <= 0:
+        raise VideoProcessingError("Uploaded video has invalid frame count metadata.")
+
+    if width <= 0 or height <= 0:
+        height, width = first_frame.shape[:2]
+    if width <= 0 or height <= 0:
+        raise VideoProcessingError("Uploaded video has invalid frame dimensions.")
+
+    duration_seconds = frame_count / fps
+    if duration_seconds <= 0:
+        raise VideoProcessingError("Uploaded video has invalid duration metadata.")
+    if duration_seconds > max_duration_seconds:
+        raise VideoProcessingError(
+            f"Uploaded video is {duration_seconds:.1f} s long. "
+            f"Current limit is {max_duration_seconds:.0f} s."
+        )
+
+    return VideoMetadata(
+        fps=fps,
+        frame_count=frame_count,
+        width=width,
+        height=height,
+        duration_seconds=duration_seconds,
+    )
+
+
+def extract_sampled_frames(
+    input_path: Path,
+    *,
+    output_dir: Path,
+    metadata: VideoMetadata,
+    sample_fps: int,
+    progress_callback: ProgressCallback | None = None,
+) -> list[SampledFrame]:
+    parsed_sample_fps = validate_sample_fps(sample_fps)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cap = cv2.VideoCapture(str(input_path))
+    if not cap.isOpened():
+        raise VideoProcessingError("Video input could not be reopened for frame extraction.")
+
+    selected_frames: list[SampledFrame] = []
+    target_interval_seconds = 1.0 / parsed_sample_fps
+    next_target_seconds = 0.0
+    frame_index = -1
+    progress_stride = max(1, metadata.frame_count // 100)
+
+    try:
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+
+            frame_index += 1
+            timestamp_seconds = frame_index / metadata.fps
+            if timestamp_seconds + 1e-9 < next_target_seconds:
+                _emit_extraction_progress(
+                    progress_callback=progress_callback,
+                    frame_index=frame_index,
+                    frame_count=metadata.frame_count,
+                    selected_count=len(selected_frames),
+                    stride=progress_stride,
+                )
+                continue
+
+            frame_path = output_dir / f"sample_{len(selected_frames):06d}.jpg"
+            if not cv2.imwrite(str(frame_path), frame):
+                raise VideoProcessingError(f"Could not save sampled frame: {frame_path}")
+
+            selected_frames.append(
+                SampledFrame(
+                    sample_index=len(selected_frames),
+                    source_frame_index=frame_index,
+                    timestamp_seconds=timestamp_seconds,
+                    path=frame_path,
+                )
+            )
+            while next_target_seconds <= timestamp_seconds + 1e-9:
+                next_target_seconds += target_interval_seconds
+
+            _emit_extraction_progress(
+                progress_callback=progress_callback,
+                frame_index=frame_index,
+                frame_count=metadata.frame_count,
+                selected_count=len(selected_frames),
+                stride=progress_stride,
+            )
+    finally:
+        cap.release()
+
+    if not selected_frames:
+        raise VideoProcessingError("Video sampling did not produce any frames.")
+
+    if progress_callback is not None:
+        progress_callback(
+            "extract",
+            1.0,
+            f"Prepared {len(selected_frames)} sampled frames.",
+        )
+    return selected_frames
+
+
+def _emit_extraction_progress(
+    *,
+    progress_callback: ProgressCallback | None,
+    frame_index: int,
+    frame_count: int,
+    selected_count: int,
+    stride: int,
+) -> None:
+    if progress_callback is None:
+        return
+    if frame_index % stride != 0 and frame_index + 1 < frame_count:
+        return
+
+    progress = min(1.0, max(0.0, (frame_index + 1) / max(1, frame_count)))
+    progress_callback(
+        "extract",
+        progress,
+        f"Sampling video frames ({selected_count} ready).",
+    )

--- a/src/murawa/vision/team_assignment.py
+++ b/src/murawa/vision/team_assignment.py
@@ -97,7 +97,7 @@ def assign_teams_to_frame(
             "min_player_box_height_px": MIN_PLAYER_BOX_HEIGHT_PX,
             "min_player_confidence": MIN_PLAYER_CONFIDENCE,
         },
-        "team_counts": _count_player_teams(enriched),
+        "team_counts": count_player_teams(enriched),
         "team_colors_bgr": _summarize_team_colors(enriched),
         "minimap_entities": len(minimap_entities),
         "notes": [
@@ -148,7 +148,7 @@ def _smooth_team_by_track_id(detections: list[dict[str, Any]]) -> list[dict[str,
     return smoothed
 
 
-def _count_player_teams(detections: list[dict[str, Any]]) -> dict[str, int]:
+def count_player_teams(detections: list[dict[str, Any]]) -> dict[str, int]:
     team_counts: Counter[str] = Counter()
 
     for det in detections:


### PR DESCRIPTION
Rozbudowałem aplikację Streamlit o analizę krótkich klipów meczowych. Dodałem upload wideo, wybór `sample_fps`, pasek postępu, generowanie wideo wynikowego z detekcjami i przypisaniem drużyn, podstawowe statystyki, pobieranie wyniku oraz widok przeglądania zapisanych analiz.

Przykład:

[match_20260521-072329_71bc8635.webm](https://github.com/user-attachments/assets/5a5cfa50-3b2a-486e-8a66-59cac82a9098)


Dodatkowo rozszerzyłem CLI o parametr `--sample-fps` i uprościłem backend analizy meczu do jednego przepływu opartego na próbkowanych klatkach. Przy okazji usunąłem zduplikowaną logikę analizy wideo z adapterów modeli oraz uporządkowałem obsługę uploadów i wspólnych helperów UI.