### PR TITLE
feat: add match tracking and stabilized video overlays

### DIFF
--- a/app/pages/analyses_page.py
+++ b/app/pages/analyses_page.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from typing import Any
 
 import streamlit as st
+from ui_common import PREVIEW_MEDIA_WIDTH, ROOT, show_counts, video_mime_type
 
 from murawa.services.saved_match_analyses import SavedMatchAnalysis, list_saved_match_analyses
-from ui_common import PREVIEW_MEDIA_WIDTH, ROOT, show_counts, video_mime_type
 
 
 def render() -> None:
@@ -68,11 +68,15 @@ def _show_summary(summary: dict[str, Any]) -> None:
 
     metadata = _mapping(summary.get("video_metadata"))
     stats = _mapping(summary.get("stats"))
-    metrics = st.columns(4)
+    tracking = _mapping(summary.get("tracking"))
+    metrics = st.columns(5)
     metrics[0].metric("Długość klipu", _duration_value(metadata.get("duration_seconds")))
     metrics[1].metric("Próbkowanie", _fps_value(summary.get("sample_fps")))
     metrics[2].metric("Klatki analizy", _count_value(summary.get("sampled_frames")))
     metrics[3].metric("Detekcje", _count_value(stats.get("total_detections")))
+    metrics[4].metric("Tracki", _count_value(stats.get("track_count")))
+    if tracking.get("enabled"):
+        st.caption(f"Tracking: `{_string_value(tracking.get('method'))}`")
 
     details = st.columns(2)
     with details[0]:

--- a/app/pages/match_page.py
+++ b/app/pages/match_page.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 
 import streamlit as st
-
-from murawa.services.pipeline import analyze_match_run
 from ui_common import (
     PREVIEW_MEDIA_WIDTH,
     ROOT,
@@ -13,11 +11,14 @@ from ui_common import (
     video_mime_type,
 )
 
+from murawa.services.pipeline import analyze_match_run
+
 PROGRESS_RANGES = {
     "validate": (0.0, 0.08),
     "extract": (0.08, 0.25),
     "inference": (0.33, 0.45),
-    "render": (0.78, 0.20),
+    "tracking": (0.78, 0.10),
+    "render": (0.88, 0.10),
     "save": (0.98, 0.02),
 }
 
@@ -50,6 +51,19 @@ def render() -> None:
         value=3,
         key="match_sample_fps",
     )
+    overlay_controls = st.columns(2)
+    with overlay_controls[0]:
+        show_boxes = st.checkbox(
+            "Ramki detekcji",
+            value=True,
+            key="match_show_boxes",
+        )
+    with overlay_controls[1]:
+        show_confidence = st.checkbox(
+            "Confidence w podpisach",
+            value=False,
+            key="match_show_confidence",
+        )
     st.caption("Obsługiwane są klipy demo do 60 sekund.")
 
     run_clicked = st.button(
@@ -73,6 +87,8 @@ def render() -> None:
                 run_name=selected_run.run_name,
                 input_path=upload_path,
                 sample_fps=sample_fps,
+                show_boxes=show_boxes,
+                show_confidence=show_confidence,
                 progress_callback=on_progress,
             )
 
@@ -94,16 +110,21 @@ def _show_match_result(result: dict) -> None:
 
     metadata = result.get("video_metadata", {})
     stats = result.get("stats", {})
+    tracking = result.get("tracking", {})
+    tracking_info = tracking if isinstance(tracking, dict) else {}
     duration = float(metadata.get("duration_seconds", 0.0))
     input_fps = float(metadata.get("fps", 0.0))
     width = int(metadata.get("width", 0))
     height = int(metadata.get("height", 0))
 
-    metrics = st.columns(4)
+    metrics = st.columns(5)
     metrics[0].metric("Długość klipu", f"{duration:.1f} s")
     metrics[1].metric("Próbkowanie", f"{result.get('sample_fps', 0)} FPS")
     metrics[2].metric("Klatki analizy", str(result.get("sampled_frames", 0)))
     metrics[3].metric("Detekcje", str(stats.get("total_detections", 0)))
+    metrics[4].metric("Tracki", str(stats.get("track_count", tracking_info.get("track_count", 0))))
+    if tracking_info.get("enabled"):
+        st.caption(f"Tracking: `{tracking_info.get('method', 'unknown')}`")
 
     if video_path.exists():
         st.video(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 numpy>=2.0
 pandas>=2.2
 opencv-python>=4.10
+supervision>=0.27
+trackers>=2.1
 matplotlib>=3.8
 streamlit>=1.35
 torch>=2.2

--- a/src/murawa/services/pipeline.py
+++ b/src/murawa/services/pipeline.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from uuid import uuid4
@@ -30,6 +30,14 @@ from murawa.vision.team_assignment_helpers import (
     read_bbox_xyxy,
     team_preview_color_bgr,
 )
+from murawa.vision.tracking import (
+    PRIMARY_BALL_MEMORY_SECONDS,
+    TRACK_SMOOTHING_WINDOW_SECONDS,
+    build_tracking_summary,
+    select_primary_ball_batches,
+    smooth_tracked_batches,
+    track_frame_batches,
+)
 
 
 def analyze_frame(
@@ -44,6 +52,8 @@ def analyze_match(
     dataset_variant: str,
     input_path: str | None = None,
     sample_fps: int = DEFAULT_SAMPLE_FPS,
+    show_boxes: bool = True,
+    show_confidence: bool = False,
     progress_callback: ProgressCallback | None = None,
 ) -> dict:
     return _run_analysis(
@@ -53,6 +63,8 @@ def analyze_match(
         mode="match",
         input_path=input_path,
         sample_fps=sample_fps,
+        show_boxes=show_boxes,
+        show_confidence=show_confidence,
         progress_callback=progress_callback,
     )
 
@@ -66,6 +78,8 @@ def analyze_match_run(
     run_name: str,
     input_path: str | None = None,
     sample_fps: int = DEFAULT_SAMPLE_FPS,
+    show_boxes: bool = True,
+    show_confidence: bool = False,
     progress_callback: ProgressCallback | None = None,
 ) -> dict:
     return _run_analysis_for_run(
@@ -74,6 +88,8 @@ def analyze_match_run(
         mode="match",
         input_path=input_path,
         sample_fps=sample_fps,
+        show_boxes=show_boxes,
+        show_confidence=show_confidence,
         progress_callback=progress_callback,
     )
 
@@ -85,10 +101,16 @@ def _run_analysis(
     mode: str,
     input_path: str | None,
     sample_fps: int = DEFAULT_SAMPLE_FPS,
+    show_boxes: bool = True,
+    show_confidence: bool = False,
     progress_callback: ProgressCallback | None = None,
 ) -> dict:
     normalized_model = normalize_model_name(model)
-    base_payload = _make_base_payload(mode=mode, model=normalized_model, dataset_variant=dataset_variant)
+    base_payload = _make_base_payload(
+        mode=mode,
+        model=normalized_model,
+        dataset_variant=dataset_variant,
+    )
 
     try:
         run_name = latest_run(project_root, normalized_model, dataset_variant)
@@ -96,7 +118,8 @@ def _run_analysis(
         base_payload["status"] = "missing_run"
         base_payload["message"] = (
             "Brak gotowego runu/checkpointu. Najpierw uruchom trening, np.: "
-            f"python scripts/train.py --model {normalized_model} --dataset-variant {dataset_variant}"
+            f"python scripts/train.py --model {normalized_model} "
+            f"--dataset-variant {dataset_variant}"
         )
         return base_payload
 
@@ -106,6 +129,8 @@ def _run_analysis(
         mode=mode,
         input_path=input_path,
         sample_fps=sample_fps,
+        show_boxes=show_boxes,
+        show_confidence=show_confidence,
         progress_callback=progress_callback,
         fallback_payload=base_payload,
     )
@@ -117,6 +142,8 @@ def _run_analysis_for_run(
     mode: str,
     input_path: str | None,
     sample_fps: int = DEFAULT_SAMPLE_FPS,
+    show_boxes: bool = True,
+    show_confidence: bool = False,
     progress_callback: ProgressCallback | None = None,
     fallback_payload: dict | None = None,
 ) -> dict:
@@ -148,6 +175,8 @@ def _run_analysis_for_run(
             dataset_variant=dataset_variant,
             input_path=input_path,
             sample_fps=sample_fps,
+            show_boxes=show_boxes,
+            show_confidence=show_confidence,
             progress_callback=progress_callback,
             base_payload=base_payload,
         )
@@ -283,6 +312,8 @@ def _run_match_video_analysis(
     dataset_variant: str,
     input_path: str | None,
     sample_fps: int,
+    show_boxes: bool,
+    show_confidence: bool,
     progress_callback: ProgressCallback | None,
     base_payload: dict,
 ) -> dict:
@@ -355,11 +386,65 @@ def _run_match_video_analysis(
                     f"({len(frame_batches)}) than sampled frames ({len(sampled_frames)})."
                 )
 
+            timeline_batches = _add_sample_timeline_batches(
+                sampled_frames=sampled_frames,
+                frame_batches=frame_batches,
+            )
+            _emit_progress(
+                progress_callback,
+                "tracking",
+                0.0,
+                "Tracking detections across sampled frames.",
+            )
+            tracked_batches = track_frame_batches(
+                timeline_batches,
+                progress_callback=lambda completed, total: _emit_tracking_progress(
+                    progress_callback=progress_callback,
+                    completed=completed,
+                    total=total,
+                    progress_start=0.0,
+                    progress_width=0.45,
+                    message="Tracking detections",
+                ),
+            )
+            team_batches, team_summaries = _assign_teams_to_match_frames(
+                sampled_frames=sampled_frames,
+                frame_batches=tracked_batches,
+                progress_callback=progress_callback,
+            )
+            _emit_progress(
+                progress_callback,
+                "tracking",
+                0.92,
+                "Smoothing tracked labels.",
+            )
+            smoothed_batches = smooth_tracked_batches(
+                team_batches,
+                window_seconds=TRACK_SMOOTHING_WINDOW_SECONDS,
+            )
+            selected_batches = select_primary_ball_batches(
+                smoothed_batches,
+                memory_seconds=PRIMARY_BALL_MEMORY_SECONDS,
+            )
+            team_summaries = [
+                _team_overlay_summary(summary=summary, detections=detections)
+                for summary, detections in zip(team_summaries, selected_batches, strict=True)
+            ]
+            _emit_progress(
+                progress_callback,
+                "tracking",
+                1.0,
+                "Tracking postprocessing is ready.",
+            )
+
             detections = _write_annotated_match_video(
                 video_path=video_path,
                 sampled_frames=sampled_frames,
-                frame_batches=frame_batches,
+                frame_batches=selected_batches,
+                team_summaries=team_summaries,
                 sample_fps=parsed_sample_fps,
+                show_boxes=show_boxes,
+                show_confidence=show_confidence,
                 progress_callback=progress_callback,
             )
     except Exception as exc:
@@ -373,6 +458,15 @@ def _run_match_video_analysis(
     stats = _build_detection_stats(detections=detections)
     stats["sampled_frames"] = len(sampled_frames)
     stats["team_counts"] = count_player_teams(detections)
+    tracking = build_tracking_summary(
+        detections,
+        window_seconds=TRACK_SMOOTHING_WINDOW_SECONDS,
+    )
+    tracking["primary_ball"] = {
+        "enabled": True,
+        "max_per_frame": 1,
+        "memory_seconds": PRIMARY_BALL_MEMORY_SECONDS,
+    }
 
     payload = {
         "status": "ok",
@@ -396,6 +490,11 @@ def _run_match_video_analysis(
         "sampled_frames": len(sampled_frames),
         "sampled_frame_timeline": [_sampled_frame_timeline_item(frame) for frame in sampled_frames],
         "stats": stats,
+        "tracking": tracking,
+        "render_options": {
+            "show_boxes": bool(show_boxes),
+            "show_confidence": bool(show_confidence),
+        },
         "team_assignment": {
             "enabled": True,
             "method": "jersey_color_kmeans_mvp_per_sampled_frame",
@@ -415,6 +514,7 @@ def _run_match_video_analysis(
                 f"sample_fps={parsed_sample_fps}",
                 f"sampled_frames={len(sampled_frames)}",
                 f"detections={stats.get('total_detections', 0)}",
+                f"tracks={tracking.get('track_count', 0)}",
                 f"video_path={video_path}",
                 "Sampled-frame video analysis output.",
                 "",
@@ -436,7 +536,10 @@ def _write_annotated_match_video(
     video_path: Path,
     sampled_frames: list[SampledFrame],
     frame_batches: list[list[dict]],
+    team_summaries: list[dict],
     sample_fps: int,
+    show_boxes: bool,
+    show_confidence: bool,
     progress_callback: ProgressCallback | None,
 ) -> list[dict]:
     writer = None
@@ -444,8 +547,8 @@ def _write_annotated_match_video(
     all_detections: list[dict] = []
 
     try:
-        for render_index, (sampled_frame, frame_detections) in enumerate(
-            zip(sampled_frames, frame_batches, strict=True),
+        for render_index, (sampled_frame, frame_detections, team_summary) in enumerate(
+            zip(sampled_frames, frame_batches, team_summaries, strict=True),
             start=1,
         ):
             frame_image_bgr = cv2.imread(str(sampled_frame.path), cv2.IMREAD_COLOR)
@@ -466,24 +569,20 @@ def _write_annotated_match_video(
             elif frame_size is not None and frame_size != (width, height):
                 frame_image_bgr = cv2.resize(frame_image_bgr, frame_size)
 
-            timeline_detections = [
-                _add_sample_timeline(detection, sampled_frame) for detection in frame_detections
-            ]
-            assignment_result = assign_teams_to_frame(
-                image_bgr=frame_image_bgr,
-                detections=timeline_detections,
-            )
             _draw_frame_overlay(
                 frame_image_bgr=frame_image_bgr,
-                detections=assignment_result.detections,
-                team_assignment=assignment_result.summary,
+                detections=frame_detections,
+                team_assignment=team_summary,
+                show_boxes=show_boxes,
+                show_confidence=show_confidence,
+                show_tracking_markers=True,
                 status_text=(
                     f"t={sampled_frame.timestamp_seconds:.2f}s "
                     f"source_frame={sampled_frame.source_frame_index}"
                 ),
             )
             writer.write(frame_image_bgr)
-            all_detections.extend(assignment_result.detections)
+            all_detections.extend(frame_detections)
             _emit_progress(
                 progress_callback,
                 "render",
@@ -497,6 +596,58 @@ def _write_annotated_match_video(
     if not video_path.exists() or video_path.stat().st_size <= 0:
         raise RuntimeError(f"Output video was not written: {video_path}")
     return all_detections
+
+
+def _add_sample_timeline_batches(
+    *,
+    sampled_frames: list[SampledFrame],
+    frame_batches: list[list[dict]],
+) -> list[list[dict]]:
+    return [
+        [_add_sample_timeline(detection, sampled_frame) for detection in frame_detections]
+        for sampled_frame, frame_detections in zip(sampled_frames, frame_batches, strict=True)
+    ]
+
+
+def _assign_teams_to_match_frames(
+    *,
+    sampled_frames: list[SampledFrame],
+    frame_batches: list[list[dict]],
+    progress_callback: ProgressCallback | None,
+) -> tuple[list[list[dict]], list[dict]]:
+    assigned_batches: list[list[dict]] = []
+    team_summaries: list[dict] = []
+
+    for batch_index, (sampled_frame, frame_detections) in enumerate(
+        zip(sampled_frames, frame_batches, strict=True),
+        start=1,
+    ):
+        frame_image_bgr = cv2.imread(str(sampled_frame.path), cv2.IMREAD_COLOR)
+        if frame_image_bgr is None:
+            raise RuntimeError(f"Could not read sampled frame: {sampled_frame.path}")
+
+        assignment_result = assign_teams_to_frame(
+            image_bgr=frame_image_bgr,
+            detections=frame_detections,
+        )
+        assigned_batches.append(assignment_result.detections)
+        team_summaries.append(assignment_result.summary)
+        _emit_tracking_progress(
+            progress_callback=progress_callback,
+            completed=batch_index,
+            total=len(sampled_frames),
+            progress_start=0.45,
+            progress_width=0.45,
+            message="Assigning teams",
+        )
+
+    return assigned_batches, team_summaries
+
+
+def _team_overlay_summary(*, summary: dict, detections: list[dict]) -> dict:
+    enriched = dict(summary)
+    enriched["team_counts"] = count_player_teams(detections)
+    return enriched
 
 
 def _add_sample_timeline(detection: dict, sampled_frame: SampledFrame) -> dict:
@@ -516,7 +667,7 @@ def _sampled_frame_timeline_item(sampled_frame: SampledFrame) -> dict:
 
 
 def _make_match_analysis_id() -> str:
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     return f"match_{timestamp}_{uuid4().hex[:8]}"
 
 
@@ -531,6 +682,23 @@ def _emit_inference_progress(
         "inference",
         completed / max(1, total),
         f"Running model inference ({completed}/{total} frames).",
+    )
+
+
+def _emit_tracking_progress(
+    *,
+    progress_callback: ProgressCallback | None,
+    completed: int,
+    total: int,
+    progress_start: float,
+    progress_width: float,
+    message: str,
+) -> None:
+    _emit_progress(
+        progress_callback,
+        "tracking",
+        progress_start + progress_width * completed / max(1, total),
+        f"{message} ({completed}/{total} frames).",
     )
 
 
@@ -563,6 +731,8 @@ def _make_base_payload(mode: str, model: str, dataset_variant: str) -> dict:
         "sample_fps": DEFAULT_SAMPLE_FPS,
         "sampled_frames": 0,
         "stats": {},
+        "tracking": {},
+        "render_options": {},
         "team_assignment": {},
         "minimap_entities": [],
         "detections": [],
@@ -572,6 +742,8 @@ def _make_base_payload(mode: str, model: str, dataset_variant: str) -> dict:
 def _build_detection_stats(detections: list[dict]) -> dict:
     by_class: dict[str, int] = {}
     confidences: list[float] = []
+    track_ids: set[int] = set()
+    tracked_detections = 0
 
     for detection in detections:
         class_name = str(detection.get("class", "unknown"))
@@ -581,10 +753,17 @@ def _build_detection_stats(detections: list[dict]) -> dict:
         if isinstance(confidence, (int, float)):
             confidences.append(float(confidence))
 
+        track_id = detection.get("track_id")
+        if isinstance(track_id, int) and not isinstance(track_id, bool):
+            track_ids.add(track_id)
+            tracked_detections += 1
+
     return {
         "total_detections": len(detections),
         "classes": by_class,
         "mean_confidence": (sum(confidences) / len(confidences)) if confidences else 0.0,
+        "track_count": len(track_ids),
+        "tracked_detections": tracked_detections,
     }
 
 
@@ -633,6 +812,9 @@ def _draw_frame_overlay(
     detections: list[dict],
     team_assignment: dict,
     status_text: str = "",
+    show_boxes: bool = True,
+    show_confidence: bool = True,
+    show_tracking_markers: bool = False,
 ) -> None:
     for detection in detections:
         bbox = read_bbox_xyxy(detection)
@@ -640,26 +822,40 @@ def _draw_frame_overlay(
             continue
 
         x1, y1, x2, y2 = bbox
-        class_name = str(detection.get("class", "unknown"))
-        confidence = detection.get("confidence")
-        confidence_text = f" {float(confidence):.2f}" if isinstance(confidence, (int, float)) else ""
-
         team = str(detection.get("team", "unknown"))
         color = team_preview_color_bgr(team)
-        label = f"{class_name}{confidence_text}"
-        if team != "unknown":
-            label = f"{label} {team}"
+        track_id = _read_detection_track_id(detection)
+
+        if show_tracking_markers:
+            marker_geometry = _draw_tracking_marker(
+                frame_image_bgr=frame_image_bgr,
+                bbox=bbox,
+                color=color,
+            )
+            _draw_tracking_marker_label(
+                frame_image_bgr=frame_image_bgr,
+                bbox=bbox,
+                marker_geometry=marker_geometry,
+                label=_build_tracking_marker_label(
+                    detection=detection,
+                    track_id=track_id,
+                    show_confidence=show_confidence,
+                ),
+            )
+
+        if not show_boxes:
+            continue
 
         cv2.rectangle(frame_image_bgr, (x1, y1), (x2, y2), color, 2)
-        cv2.putText(
-            frame_image_bgr,
-            label,
-            (x1, max(15, y1 - 6)),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.5,
-            color,
-            2,
-        )
+        if not show_tracking_markers:
+            _draw_shadowed_text(
+                image_bgr=frame_image_bgr,
+                text=_build_bbox_label(detection=detection, show_confidence=show_confidence),
+                origin=(x1, max(15, y1 - 6)),
+                font_scale=0.5,
+                color=color,
+                thickness=2,
+            )
 
     legend_bottom = _draw_team_legend(
         image_bgr=frame_image_bgr,
@@ -688,6 +884,189 @@ def _draw_frame_overlay(
             (255, 255, 255),
             2,
         )
+
+
+def _draw_tracking_marker(
+    *,
+    frame_image_bgr: np.ndarray,
+    bbox: tuple[int, int, int, int],
+    color: tuple[int, int, int],
+) -> tuple[int, int, int]:
+    x1, y1, x2, y2 = bbox
+    box_width = max(1, x2 - x1)
+    box_height = max(1, y2 - y1)
+    image_height, image_width = frame_image_bgr.shape[:2]
+
+    radius_x = max(8, min(44, int(round(box_width * 0.48))))
+    radius_y = max(4, min(14, int(round(box_height * 0.12))))
+    center_x = max(radius_x, min(image_width - radius_x - 1, (x1 + x2) // 2))
+    center_y = min(image_height - 2, y2 + radius_y + 2)
+
+    backing = frame_image_bgr.copy()
+    cv2.ellipse(
+        backing,
+        (center_x, center_y),
+        (radius_x + 3, radius_y + 3),
+        0,
+        0,
+        180,
+        (0, 0, 0),
+        -1,
+    )
+    cv2.addWeighted(backing, 0.56, frame_image_bgr, 0.44, 0, frame_image_bgr)
+
+    overlay = frame_image_bgr.copy()
+    cv2.ellipse(
+        overlay,
+        (center_x, center_y),
+        (radius_x, radius_y),
+        0,
+        0,
+        180,
+        color,
+        -1,
+    )
+    cv2.addWeighted(overlay, 0.62, frame_image_bgr, 0.38, 0, frame_image_bgr)
+    cv2.ellipse(
+        frame_image_bgr,
+        (center_x, center_y),
+        (radius_x + 2, radius_y + 2),
+        0,
+        0,
+        180,
+        (0, 0, 0),
+        5,
+    )
+    cv2.ellipse(
+        frame_image_bgr,
+        (center_x, center_y),
+        (radius_x, radius_y),
+        0,
+        0,
+        180,
+        color,
+        3,
+    )
+    return center_x, center_y, radius_y
+
+
+def _draw_tracking_marker_label(
+    *,
+    frame_image_bgr: np.ndarray,
+    bbox: tuple[int, int, int, int],
+    marker_geometry: tuple[int, int, int],
+    label: str,
+) -> None:
+    if not label:
+        return
+
+    center_x, center_y, radius_y = marker_geometry
+    font_scale = 0.68
+    thickness = 2
+    (text_width, text_height), baseline = cv2.getTextSize(
+        label,
+        cv2.FONT_HERSHEY_SIMPLEX,
+        font_scale,
+        thickness,
+    )
+    image_height, image_width = frame_image_bgr.shape[:2]
+    x = max(4, min(image_width - text_width - 4, center_x - text_width // 2))
+    y = center_y + radius_y + text_height + 10
+    if y + baseline > image_height - 4:
+        y = max(text_height + 6, bbox[1] - 10)
+
+    _draw_shadowed_text(
+        image_bgr=frame_image_bgr,
+        text=label,
+        origin=(x, y),
+        font_scale=font_scale,
+        color=(255, 255, 255),
+        thickness=thickness,
+    )
+
+
+def _draw_shadowed_text(
+    *,
+    image_bgr: np.ndarray,
+    text: str,
+    origin: tuple[int, int],
+    font_scale: float,
+    color: tuple[int, int, int],
+    thickness: int,
+) -> None:
+    shadow_origin = (origin[0] + 2, origin[1] + 2)
+    cv2.putText(
+        image_bgr,
+        text,
+        shadow_origin,
+        cv2.FONT_HERSHEY_SIMPLEX,
+        font_scale,
+        (0, 0, 0),
+        thickness + 2,
+        cv2.LINE_AA,
+    )
+    cv2.putText(
+        image_bgr,
+        text,
+        origin,
+        cv2.FONT_HERSHEY_SIMPLEX,
+        font_scale,
+        color,
+        thickness,
+        cv2.LINE_AA,
+    )
+
+
+def _build_tracking_marker_label(
+    *,
+    detection: dict,
+    track_id: int | None,
+    show_confidence: bool,
+) -> str:
+    label = _display_team_label(detection.get("team"))
+    if label is None:
+        label = _display_class_label(detection.get("class"))
+    if track_id is not None:
+        label = f"{label} #{track_id}"
+    confidence_text = _confidence_text(detection=detection, show_confidence=show_confidence)
+    return f"{label}{confidence_text}"
+
+
+def _build_bbox_label(*, detection: dict, show_confidence: bool) -> str:
+    label = _display_class_label(detection.get("class"))
+    label = f"{label}{_confidence_text(detection=detection, show_confidence=show_confidence)}"
+    team_label = _display_team_label(detection.get("team"))
+    if team_label is not None:
+        label = f"{label} {team_label}"
+    return label
+
+
+def _confidence_text(*, detection: dict, show_confidence: bool) -> str:
+    confidence = detection.get("confidence")
+    if show_confidence and isinstance(confidence, (int, float)):
+        return f" {float(confidence):.2f}"
+    return ""
+
+
+def _display_class_label(value: object) -> str:
+    class_name = normalize_class_name(value) or "object"
+    return class_name.replace("_", " ").title()
+
+
+def _display_team_label(value: object) -> str | None:
+    labels = {
+        "team_a": "TeamA",
+        "team_b": "TeamB",
+        "referee": "Referee",
+    }
+    return labels.get(str(value))
+
+
+def _read_detection_track_id(detection: dict) -> int | None:
+    track_id = detection.get("track_id")
+    if isinstance(track_id, int) and not isinstance(track_id, bool):
+        return track_id
+    return None
 
 
 def _draw_team_legend(
@@ -754,7 +1133,10 @@ def _write_team_assignment_debug_preview(
     return [str(debug_path)]
 
 
-def _build_team_assignment_crop_sheet(frame_image_bgr: np.ndarray, detections: list[dict]) -> np.ndarray:
+def _build_team_assignment_crop_sheet(
+    frame_image_bgr: np.ndarray,
+    detections: list[dict],
+) -> np.ndarray:
     tile_width = 170
     tile_height = 116
     crop_size = 64

--- a/src/murawa/vision/team_assignment.py
+++ b/src/murawa/vision/team_assignment.py
@@ -17,7 +17,6 @@ from murawa.vision.team_assignment_helpers import (
     read_bbox_xyxy,
 )
 
-
 PLAYER_CLASSES = {"player", "goalkeeper"}
 REFEREE_CLASSES = {"referee"}
 
@@ -135,13 +134,6 @@ def _smooth_team_by_track_id(detections: list[dict[str, Any]]) -> list[dict[str,
         team_votes = votes_by_track[track_id]
         final_team, final_votes = team_votes.most_common(1)[0]
         total_votes = sum(team_votes.values())
-        previous_team = det.get("team")
-
-        if previous_team != final_team:
-            det["team_raw"] = previous_team
-            det["team_confidence_raw"] = det.get("team_confidence")
-            det["team_smoothed"] = True
-
         det["team"] = final_team
         det["team_confidence"] = round(final_votes / total_votes, 4)
 

--- a/src/murawa/vision/tracking.py
+++ b/src/murawa/vision/tracking.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict, deque
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import supervision as sv
+
+from murawa.vision.team_assignment_helpers import normalize_class_name, read_bbox_xyxy
+
+TRACKING_METHOD = "bytetrack"
+TRACK_SMOOTHING_WINDOW_SECONDS = 15.0
+PRIMARY_BALL_MEMORY_SECONDS = 2.0
+_TRACK_MATCH_MIN_IOU = 0.05
+_BALL_CLASSES = {"ball"}
+_TEAM_LABELS = {"team_a", "team_b"}
+
+DetectionBatch = list[dict[str, Any]]
+TrackingProgressCallback = Callable[[int, int], None]
+
+
+@dataclass(frozen=True)
+class _TrackingInput:
+    detections: sv.Detections
+    source_indexes: list[int]
+
+
+@dataclass(frozen=True)
+class _TrackObservation:
+    timestamp_seconds: float
+    class_name: str
+    team: str | None
+
+
+def track_frame_batches(
+    frame_batches: list[DetectionBatch],
+    *,
+    tracker: Any | None = None,
+    progress_callback: TrackingProgressCallback | None = None,
+) -> list[DetectionBatch]:
+    """Attach ByteTrack IDs to frame detections without dropping detector output."""
+    byte_tracker = tracker if tracker is not None else _build_bytetrack_tracker()
+    class_ids: dict[str, int] = {}
+    tracked_batches: list[DetectionBatch] = []
+    total_batches = len(frame_batches)
+
+    for batch_index, batch in enumerate(frame_batches, start=1):
+        enriched = [dict(detection, track_id=None) for detection in batch]
+        tracking_input = _build_tracking_input(batch=batch, class_ids=class_ids)
+        tracked = byte_tracker.update(tracking_input.detections)
+        _copy_tracker_ids(
+            detections=enriched,
+            tracking_input=tracking_input,
+            tracked=tracked,
+        )
+        tracked_batches.append(enriched)
+        if progress_callback is not None:
+            progress_callback(batch_index, total_batches)
+
+    return tracked_batches
+
+
+def smooth_tracked_batches(
+    frame_batches: list[DetectionBatch],
+    *,
+    window_seconds: float = TRACK_SMOOTHING_WINDOW_SECONDS,
+) -> list[DetectionBatch]:
+    """Smooth class and player-team labels using recent observations of each track."""
+    if window_seconds <= 0:
+        raise ValueError("Tracking smoothing window must be positive.")
+
+    history: dict[int, deque[_TrackObservation]] = defaultdict(deque)
+    smoothed_batches: list[DetectionBatch] = []
+
+    for batch in frame_batches:
+        smoothed_batch: DetectionBatch = []
+        for detection in batch:
+            enriched = dict(detection)
+            track_id = _read_track_id(enriched.get("track_id"))
+            timestamp_seconds = _read_timestamp(enriched.get("timestamp_seconds"))
+            if track_id is None or timestamp_seconds is None:
+                smoothed_batch.append(enriched)
+                continue
+
+            observations = history[track_id]
+            _discard_stale_observations(
+                observations=observations,
+                timestamp_seconds=timestamp_seconds,
+                window_seconds=window_seconds,
+            )
+            observations.append(
+                _TrackObservation(
+                    timestamp_seconds=timestamp_seconds,
+                    class_name=str(enriched.get("class", "")),
+                    team=_read_team_label(enriched.get("team")),
+                )
+            )
+
+            final_class = _strict_majority(
+                observation.class_name
+                for observation in observations
+                if normalize_class_name(observation.class_name)
+            )
+            if final_class is not None:
+                enriched["class"] = final_class
+
+            team_votes = [
+                observation.team
+                for observation in observations
+                if observation.team in _TEAM_LABELS
+            ]
+            final_team = _strict_majority(team_votes)
+            if final_team is not None:
+                enriched["team"] = final_team
+                enriched["team_confidence"] = round(
+                    team_votes.count(final_team) / len(team_votes),
+                    4,
+                )
+
+            smoothed_batch.append(enriched)
+        smoothed_batches.append(smoothed_batch)
+
+    return smoothed_batches
+
+
+def select_primary_ball_batches(
+    frame_batches: list[DetectionBatch],
+    *,
+    memory_seconds: float = PRIMARY_BALL_MEMORY_SECONDS,
+) -> list[DetectionBatch]:
+    """Keep one rendered ball per frame, preferring the recent selected ball track."""
+    if memory_seconds < 0:
+        raise ValueError("Primary ball memory window must be non-negative.")
+
+    selected_track_id: int | None = None
+    selected_timestamp: float | None = None
+    selected_batches: list[DetectionBatch] = []
+
+    for batch in frame_batches:
+        ball_candidates: list[tuple[int, dict[str, Any]]] = []
+        for detection_index, detection in enumerate(batch):
+            if _is_ball_detection(detection):
+                ball_candidates.append((detection_index, detection))
+
+        if len(ball_candidates) <= 1:
+            selected_batches.append([dict(detection) for detection in batch])
+            if ball_candidates:
+                selected_track_id, selected_timestamp = _remember_selected_ball(
+                    detection=ball_candidates[0][1],
+                    fallback_track_id=selected_track_id,
+                    fallback_timestamp=selected_timestamp,
+                )
+            continue
+
+        selected_index, selected_detection = _select_primary_ball_candidate(
+            ball_candidates=ball_candidates,
+            selected_track_id=selected_track_id,
+            selected_timestamp=selected_timestamp,
+            memory_seconds=memory_seconds,
+        )
+        selected_batches.append(
+            [
+                dict(detection)
+                for detection_index, detection in enumerate(batch)
+                if not _is_ball_detection(detection) or detection_index == selected_index
+            ]
+        )
+        selected_track_id, selected_timestamp = _remember_selected_ball(
+            detection=selected_detection,
+            fallback_track_id=selected_track_id,
+            fallback_timestamp=selected_timestamp,
+        )
+
+    return selected_batches
+
+
+def build_tracking_summary(
+    detections: Iterable[dict[str, Any]],
+    *,
+    window_seconds: float = TRACK_SMOOTHING_WINDOW_SECONDS,
+) -> dict[str, Any]:
+    track_ids: set[int] = set()
+    tracked_detections = 0
+    for detection in detections:
+        track_id = _read_track_id(detection.get("track_id"))
+        if track_id is None:
+            continue
+        track_ids.add(track_id)
+        tracked_detections += 1
+    return {
+        "enabled": True,
+        "method": TRACKING_METHOD,
+        "tracked_classes": "all",
+        "track_count": len(track_ids),
+        "tracked_detections": tracked_detections,
+        "smoothing": {
+            "enabled": True,
+            "window_seconds": float(window_seconds),
+            "labels": ["class", "team"],
+        },
+    }
+
+
+def _build_bytetrack_tracker() -> Any:
+    try:
+        from trackers import ByteTrackTracker
+    except ImportError as exc:
+        raise RuntimeError(
+            "ByteTrack backend is unavailable. Install dependencies with: pip install trackers"
+        ) from exc
+    return ByteTrackTracker()
+
+
+def _build_tracking_input(batch: DetectionBatch, class_ids: dict[str, int]) -> _TrackingInput:
+    xyxy: list[list[float]] = []
+    confidences: list[float] = []
+    detection_class_ids: list[int] = []
+    source_indexes: list[int] = []
+
+    for source_index, detection in enumerate(batch):
+        bbox = read_bbox_xyxy(detection)
+        if bbox is None:
+            continue
+
+        class_key = normalize_class_name(detection.get("class")) or "unknown"
+        if class_key not in class_ids:
+            class_ids[class_key] = len(class_ids)
+
+        source_indexes.append(source_index)
+        xyxy.append([float(value) for value in bbox])
+        confidences.append(_read_confidence(detection.get("confidence")))
+        detection_class_ids.append(class_ids[class_key])
+
+    detections = sv.Detections(
+        xyxy=np.asarray(xyxy, dtype=np.float32).reshape((-1, 4)),
+        confidence=np.asarray(confidences, dtype=np.float32),
+        class_id=np.asarray(detection_class_ids, dtype=int),
+        data={"source_index": np.asarray(source_indexes, dtype=int)},
+    )
+    return _TrackingInput(detections=detections, source_indexes=source_indexes)
+
+
+def _copy_tracker_ids(
+    *,
+    detections: DetectionBatch,
+    tracking_input: _TrackingInput,
+    tracked: sv.Detections,
+) -> None:
+    tracker_ids = _tracker_ids(tracked)
+    if len(tracker_ids) == 0:
+        return
+
+    if _copy_tracker_ids_from_data(detections=detections, tracked=tracked, tracker_ids=tracker_ids):
+        return
+
+    original_boxes = np.asarray(tracking_input.detections.xyxy, dtype=np.float32).reshape((-1, 4))
+    tracked_boxes = np.asarray(getattr(tracked, "xyxy", []), dtype=np.float32).reshape((-1, 4))
+    if len(original_boxes) == 0 or len(tracked_boxes) == 0:
+        return
+
+    candidate_matches: list[tuple[float, int, int]] = []
+    for tracked_index, tracked_box in enumerate(tracked_boxes):
+        if tracked_index >= len(tracker_ids) or tracker_ids[tracked_index] is None:
+            continue
+        for original_index, original_box in enumerate(original_boxes):
+            candidate_matches.append(
+                (_bbox_iou(tracked_box, original_box), tracked_index, original_index)
+            )
+
+    claimed_tracked_indexes: set[int] = set()
+    claimed_original_indexes: set[int] = set()
+    for iou, tracked_index, original_index in sorted(candidate_matches, reverse=True):
+        if iou < _TRACK_MATCH_MIN_IOU:
+            break
+        if tracked_index in claimed_tracked_indexes or original_index in claimed_original_indexes:
+            continue
+
+        source_index = tracking_input.source_indexes[original_index]
+        detections[source_index]["track_id"] = tracker_ids[tracked_index]
+        claimed_tracked_indexes.add(tracked_index)
+        claimed_original_indexes.add(original_index)
+
+
+def _copy_tracker_ids_from_data(
+    *,
+    detections: DetectionBatch,
+    tracked: sv.Detections,
+    tracker_ids: list[int | None],
+) -> bool:
+    data = getattr(tracked, "data", {})
+    if not isinstance(data, dict):
+        return False
+    source_indexes = data.get("source_index")
+    if source_indexes is None:
+        return False
+
+    indexes = np.asarray(source_indexes).reshape((-1,)).tolist()
+    if len(indexes) != len(tracker_ids):
+        return False
+
+    copied = False
+    for source_index, track_id in zip(indexes, tracker_ids, strict=True):
+        if track_id is None:
+            continue
+        try:
+            parsed_index = int(source_index)
+        except (TypeError, ValueError):
+            continue
+        if 0 <= parsed_index < len(detections):
+            detections[parsed_index]["track_id"] = track_id
+            copied = True
+    return copied
+
+
+def _tracker_ids(tracked: sv.Detections) -> list[int | None]:
+    raw_tracker_ids = getattr(tracked, "tracker_id", None)
+    if raw_tracker_ids is None:
+        return []
+    return [_read_track_id(track_id) for track_id in np.asarray(raw_tracker_ids).reshape((-1,))]
+
+
+def _read_track_id(value: object) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _read_timestamp(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_confidence(value: object) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _read_team_label(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return value if value in _TEAM_LABELS else None
+
+
+def _select_primary_ball_candidate(
+    *,
+    ball_candidates: list[tuple[int, dict[str, Any]]],
+    selected_track_id: int | None,
+    selected_timestamp: float | None,
+    memory_seconds: float,
+) -> tuple[int, dict[str, Any]]:
+    recent_track_candidates = [
+        candidate
+        for candidate in ball_candidates
+        if _continues_selected_ball_track(
+            detection=candidate[1],
+            selected_track_id=selected_track_id,
+            selected_timestamp=selected_timestamp,
+            memory_seconds=memory_seconds,
+        )
+    ]
+    candidates = recent_track_candidates or ball_candidates
+    return max(candidates, key=lambda candidate: _read_confidence(candidate[1].get("confidence")))
+
+
+def _continues_selected_ball_track(
+    *,
+    detection: dict[str, Any],
+    selected_track_id: int | None,
+    selected_timestamp: float | None,
+    memory_seconds: float,
+) -> bool:
+    track_id = _read_track_id(detection.get("track_id"))
+    timestamp = _read_timestamp(detection.get("timestamp_seconds"))
+    if (
+        track_id is None
+        or selected_track_id is None
+        or timestamp is None
+        or selected_timestamp is None
+    ):
+        return False
+    return track_id == selected_track_id and timestamp - selected_timestamp <= memory_seconds
+
+
+def _remember_selected_ball(
+    *,
+    detection: dict[str, Any],
+    fallback_track_id: int | None,
+    fallback_timestamp: float | None,
+) -> tuple[int | None, float | None]:
+    track_id = _read_track_id(detection.get("track_id"))
+    timestamp = _read_timestamp(detection.get("timestamp_seconds"))
+    if track_id is None or timestamp is None:
+        return fallback_track_id, fallback_timestamp
+    return track_id, timestamp
+
+
+def _is_ball_detection(detection: dict[str, Any]) -> bool:
+    return normalize_class_name(detection.get("class")) in _BALL_CLASSES
+
+
+def _discard_stale_observations(
+    *,
+    observations: deque[_TrackObservation],
+    timestamp_seconds: float,
+    window_seconds: float,
+) -> None:
+    cutoff = timestamp_seconds - window_seconds
+    while observations and observations[0].timestamp_seconds < cutoff:
+        observations.popleft()
+
+
+def _strict_majority(values: Iterable[str | None]) -> str | None:
+    cleaned = [value for value in values if isinstance(value, str) and value]
+    if not cleaned:
+        return None
+
+    winner, winner_count = Counter(cleaned).most_common(1)[0]
+    if winner_count <= len(cleaned) / 2:
+        return None
+    return winner
+
+
+def _bbox_iou(first: np.ndarray, second: np.ndarray) -> float:
+    intersection_x1 = max(float(first[0]), float(second[0]))
+    intersection_y1 = max(float(first[1]), float(second[1]))
+    intersection_x2 = min(float(first[2]), float(second[2]))
+    intersection_y2 = min(float(first[3]), float(second[3]))
+    intersection_width = max(0.0, intersection_x2 - intersection_x1)
+    intersection_height = max(0.0, intersection_y2 - intersection_y1)
+    intersection_area = intersection_width * intersection_height
+    if intersection_area <= 0.0:
+        return 0.0
+
+    first_area = max(0.0, float(first[2]) - float(first[0])) * max(
+        0.0, float(first[3]) - float(first[1])
+    )
+    second_area = max(0.0, float(second[2]) - float(second[0])) * max(
+        0.0, float(second[3]) - float(second[1])
+    )
+    union_area = first_area + second_area - intersection_area
+    if union_area <= 0.0:
+        return 0.0
+    return intersection_area / union_area


### PR DESCRIPTION
rezultat:

https://github.com/user-attachments/assets/a908bf32-1f1c-4b38-90c8-3f2cfa16f4cc

A więc tak, dodałem tracking obiektów do analizy wideo, żeby detekcje z kolejnych klatek były powiązane w czasie przez `track_id`.
- w `src/murawa/vision/tracking.py` dodałem moduł trackingu oparty o `ByteTrack`. To polecane przez rf-detr z opisu issue
- w `src/murawa/services/pipeline.py` wpiąłem tracking 
- w pipeline dodałem takie "ala" glosowanie, zeby nie bylo migania. Ogranicza to efekt "migania" z teamA/teamB