### PR TITLE
Improve Streamlit result presentation and video smoothing #20

### DIFF
--- a/app/pages/frame_page.py
+++ b/app/pages/frame_page.py
@@ -39,7 +39,12 @@ def render() -> None:
 
     result = st.session_state.get("frame_last_result")
     if isinstance(result, dict):
-        show_result(result, show_debug_assets=show_team_debug)
+        input_preview = uploaded.getvalue() if uploaded is not None else None
+        show_result(
+            result,
+            show_debug_assets=show_team_debug,
+            input_image=input_preview,
+        )
 
 
 if __name__ == "__main__":

--- a/app/pages/match_page.py
+++ b/app/pages/match_page.py
@@ -135,7 +135,7 @@ def _show_match_result(result: dict) -> None:
         actions = st.columns([1, 2])
         with actions[0]:
             st.download_button(
-                "Pobierz wynik",
+                "Pobierz wynik wideo",
                 data=video_path.read_bytes(),
                 file_name=video_path.name,
                 mime=video_mime_type(video_path),
@@ -156,7 +156,8 @@ def _show_match_result(result: dict) -> None:
         show_counts("Klasy detekcji", stats.get("classes", {}), "Klasa")
     with details[2]:
         show_counts("Drużyny", stats.get("team_counts", {}), "Etykieta")
-
+    with st.expander("Raw summary", expanded=False):
+        st.json(result)
 
 if __name__ == "__main__":
     render()

--- a/app/ui_common.py
+++ b/app/ui_common.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-
+import numpy as np
 import streamlit as st
 
 from murawa.services.artifacts import TrainedRunRecord, list_available_runs
@@ -70,36 +71,32 @@ def video_mime_type(video_path: Path) -> str:
     return "video/mp4"
 
 
-def show_result(result: dict, show_debug_assets: bool = False) -> None:
+def show_result(
+    result: dict,
+    show_debug_assets: bool = False,
+    input_image: bytes | str | Path | None = None,
+) -> None:
     if result["status"] == "missing_run":
         st.info(result["message"])
         return
 
     if result["status"] != "ok":
         st.error(result.get("message", "Analiza zakończyła się błędem."))
+        with st.expander("Szczegóły błędu", expanded=False):
+            st.json(result)
+        return
+
+    if result.get("mode") == "frame":
+        _show_frame_result(
+            result=result,
+            show_debug_assets=show_debug_assets,
+            input_image=input_image,
+        )
         return
 
     st.success("Przetwarzanie zakończone.")
-    st.json(result)
-
-    preview_path = Path(result.get("preview_path", ""))
-    if preview_path.exists():
-        st.text_area("Podgląd wyniku", preview_path.read_text(encoding="utf-8"), height=160)
-
-    preview_assets = result.get("preview_assets", [])
-    for asset in preview_assets[:3]:
-        preview_file = Path(asset)
-        if preview_file.exists():
-            _show_preview_image(preview_file)
-
-    if not show_debug_assets:
-        return
-
-    debug_assets = result.get("debug_preview_assets", [])
-    for asset in debug_assets[:3]:
-        debug_file = Path(asset)
-        if debug_file.exists():
-            _show_preview_image(debug_file)
+    with st.expander("Raw result", expanded=False):
+        st.json(result)
 
 
 def _show_preview_image(preview_file: Path) -> None:
@@ -109,3 +106,370 @@ def _show_preview_image(preview_file: Path) -> None:
             caption=preview_file.name,
             width="stretch",
         )
+
+def _show_frame_result(
+    *,
+    result: dict,
+    show_debug_assets: bool,
+    input_image: bytes | str | Path | None,
+) -> None:
+    st.success("Analiza klatki zakończona.")
+
+    stats = _mapping(result.get("stats"))
+    team_assignment = _mapping(result.get("team_assignment"))
+    detections = _list_of_dicts(result.get("detections"))
+    minimap_entities = _list_of_dicts(result.get("minimap_entities"))
+
+    _show_frame_metrics(
+        stats=stats,
+        team_assignment=team_assignment,
+        minimap_entities=minimap_entities,
+    )
+
+    st.divider()
+    _show_frame_previews(result=result, input_image=input_image)
+
+    st.divider()
+    summary_tab, team_tab, minimap_tab, raw_tab = st.tabs(
+        ["Podsumowanie", "Drużyny", "Minimapa", "Raw JSON"]
+    )
+
+    with summary_tab:
+        cols = st.columns(2)
+        with cols[0]:
+            show_counts("Klasy detekcji", stats.get("classes", {}), "Klasa")
+        with cols[1]:
+            _show_primary_ball_filter(result)
+
+        st.markdown("**Detekcje**")
+        rows = _detection_rows(detections)
+        if rows:
+            st.dataframe(rows, hide_index=True, height="content", use_container_width=True)
+        else:
+            st.caption("Brak detekcji do pokazania.")
+
+    with team_tab:
+        cols = st.columns(2)
+        with cols[0]:
+            show_counts("Podsumowanie drużyn", team_assignment.get("team_counts", {}), "Etykieta")
+        with cols[1]:
+            _show_team_colors(team_assignment)
+
+        st.markdown("**Wizualizacja cech kolorów koszulek**")
+        _show_team_feature_scatter(detections)
+
+        if show_debug_assets:
+            st.markdown("**Debug cropów koszulek**")
+            for asset in _list_of_strings(result.get("debug_preview_assets"))[:3]:
+                debug_file = Path(asset)
+                if debug_file.exists():
+                    _show_preview_image(debug_file)
+
+    with minimap_tab:
+        _show_minimap_entities(minimap_entities)
+
+    with raw_tab:
+        st.json(result)
+
+
+def _show_frame_metrics(
+    *,
+    stats: dict[str, Any],
+    team_assignment: dict[str, Any],
+    minimap_entities: list[dict[str, Any]],
+) -> None:
+    class_counts = _mapping(stats.get("classes"))
+    team_counts = _mapping(team_assignment.get("team_counts"))
+
+    metrics = st.columns(5)
+    metrics[0].metric("Detekcje", _count_value(stats.get("total_detections")))
+    metrics[1].metric("Klasy", str(len(class_counts)))
+    metrics[2].metric("Śr. confidence", _confidence_value(stats.get("mean_confidence")))
+    metrics[3].metric("Drużyny / role", str(len(team_counts)))
+    metrics[4].metric("Minimap entities", str(len(minimap_entities)))
+
+
+def _show_frame_previews(
+    *,
+    result: dict,
+    input_image: bytes | str | Path | None,
+) -> None:
+    left, right = st.columns(2)
+
+    with left:
+        st.markdown("**Klatka wejściowa**")
+        if input_image is not None:
+            st.image(input_image, caption="Input", width="stretch")
+        else:
+            resolved_input = _safe_path(result.get("resolved_input"))
+            if resolved_input is not None and resolved_input.exists():
+                st.image(str(resolved_input), caption=resolved_input.name, width="stretch")
+            else:
+                st.caption("Brak dostępnego podglądu wejścia.")
+
+    with right:
+        st.markdown("**Wynik analizy**")
+        preview_file = _first_existing_path(_list_of_strings(result.get("preview_assets")))
+        if preview_file is not None:
+            st.image(str(preview_file), caption=preview_file.name, width="stretch")
+        else:
+            st.caption("Brak wygenerowanego preview.")
+
+
+def _show_primary_ball_filter(result: dict) -> None:
+    primary_ball = _mapping(result.get("primary_ball_filter"))
+    st.markdown("**Filtrowanie piłki**")
+    if not primary_ball:
+        st.caption("Brak danych.")
+        return
+
+    st.table(
+        [
+            {"Pole": "Włączone", "Wartość": str(primary_ball.get("enabled", False))},
+            {"Pole": "Polityka", "Wartość": str(primary_ball.get("policy", "brak"))},
+            {"Pole": "Detekcje przed", "Wartość": _count_value(primary_ball.get("raw_detection_count"))},
+            {"Pole": "Detekcje po", "Wartość": _count_value(primary_ball.get("filtered_detection_count"))},
+            {"Pole": "Piłki po", "Wartość": _count_value(primary_ball.get("ball_candidates_after"))},
+        ]
+    )
+
+
+def _show_team_colors(team_assignment: dict[str, Any]) -> None:
+    colors = _mapping(team_assignment.get("team_colors_bgr"))
+    st.markdown("**Kolory drużyn**")
+    if not colors:
+        st.caption("Brak danych o kolorach.")
+        return
+
+    rows = []
+    for team, color in sorted(colors.items()):
+        if not isinstance(color, list) or len(color) != 3:
+            continue
+        b, g, r = [int(v) for v in color]
+        rows.append(
+            {
+                "Etykieta": team,
+                "BGR": f"[{b}, {g}, {r}]",
+                "RGB": f"[{r}, {g}, {b}]",
+            }
+        )
+
+    if rows:
+        st.table(rows)
+    else:
+        st.caption("Brak poprawnych kolorów.")
+
+
+def _show_team_feature_scatter(detections: list[dict[str, Any]]) -> None:
+    rows = _team_feature_rows(detections)
+    if len(rows) < 2:
+        st.caption("Za mało zawodników z kolorem koszulki, żeby pokazać wykres.")
+        return
+
+    projection_name = rows[0].get("projection", "2D projection")
+
+    st.caption(
+        f"Wizualizacja pomocnicza: `{projection_name}`. "
+        "UMAP jest używany, jeżeli `umap-learn` jest dostępny; inaczej używany jest fallback PCA."
+    )
+
+    spec = {
+        "data": {"values": rows},
+        "mark": {"type": "circle", "size": 180, "opacity": 0.9},
+        "encoding": {
+            "x": {
+                "field": "x",
+                "type": "quantitative",
+                "title": "feature 1",
+                "scale": {"zero": False},
+            },
+            "y": {
+                "field": "y",
+                "type": "quantitative",
+                "title": "feature 2",
+                "scale": {"zero": False},
+            },
+            "color": {
+                "field": "team",
+                "type": "nominal",
+                "title": "team",
+            },
+            "shape": {
+                "field": "class",
+                "type": "nominal",
+                "title": "class",
+            },
+            "tooltip": [
+                {"field": "class", "type": "nominal"},
+                {"field": "team", "type": "nominal"},
+                {"field": "confidence", "type": "quantitative"},
+                {"field": "jersey_color_bgr", "type": "nominal"},
+                {"field": "x", "type": "quantitative"},
+                {"field": "y", "type": "quantitative"},
+            ],
+        },
+        "height": 360,
+    }
+
+    st.vega_lite_chart(spec=spec, use_container_width=True)
+
+
+def _show_minimap_entities(minimap_entities: list[dict[str, Any]]) -> None:
+    if not minimap_entities:
+        st.caption("Brak danych minimapy.")
+        return
+
+    rows = []
+    for entity in minimap_entities:
+        rows.append(
+            {
+                "class": entity.get("class", "unknown"),
+                "team": entity.get("team", "unknown"),
+                "center_xy": entity.get("center_xy"),
+                "bbox_xyxy": entity.get("bbox_xyxy"),
+                "confidence": _round_float(entity.get("confidence")),
+                "track_id": entity.get("track_id", ""),
+                "frame_index": entity.get("frame_index", ""),
+            }
+        )
+
+    st.dataframe(rows, hide_index=True, height="content", use_container_width=True)
+
+
+def _team_feature_rows(detections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    features: list[list[float]] = []
+    metadata: list[dict[str, Any]] = []
+
+    for det in detections:
+        color = det.get("jersey_color_bgr")
+        if not isinstance(color, list) or len(color) != 3:
+            continue
+
+        try:
+            b, g, r = [float(channel) for channel in color]
+        except (TypeError, ValueError):
+            continue
+
+        brightness = (r + g + b) / 3.0
+        red_blue_delta = r - b
+        saturation_proxy = max(r, g, b) - min(r, g, b)
+
+        features.append([r, g, b, brightness, red_blue_delta, saturation_proxy])
+        metadata.append(
+            {
+                "class": str(det.get("class", "unknown")),
+                "team": str(det.get("team", "unknown")),
+                "confidence": _round_float(det.get("confidence")),
+                "jersey_color_bgr": str([int(b), int(g), int(r)]),
+            }
+        )
+
+    if not features:
+        return []
+
+    coords, method = _project_2d(np.array(features, dtype=np.float32))
+    return [
+        {
+            **metadata[idx],
+            "x": round(float(coords[idx, 0]), 4),
+            "y": round(float(coords[idx, 1]), 4),
+            "projection": method,
+        }
+        for idx in range(len(metadata))
+    ]
+
+
+def _project_2d(features: np.ndarray) -> tuple[np.ndarray, str]:
+    if len(features) == 1:
+        return np.zeros((1, 2), dtype=np.float32), "single-point projection"
+
+    try:
+        import umap  # type: ignore
+
+        if len(features) >= 4:
+            reducer = umap.UMAP(
+                n_components=2,
+                n_neighbors=min(8, len(features) - 1),
+                min_dist=0.05,
+                random_state=42,
+            )
+            return reducer.fit_transform(features).astype(np.float32), "UMAP"
+    except Exception:
+        pass
+
+    centered = features - features.mean(axis=0, keepdims=True)
+    _, _, vt = np.linalg.svd(centered, full_matrices=False)
+    components = vt[:2].T
+    coords = centered @ components
+
+    if coords.shape[1] == 1:
+        coords = np.hstack([coords, np.zeros((len(coords), 1), dtype=coords.dtype)])
+
+    return coords[:, :2].astype(np.float32), "PCA fallback"
+
+
+def _detection_rows(detections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows = []
+    for idx, det in enumerate(detections[:80], start=1):
+        rows.append(
+            {
+                "#": idx,
+                "class": det.get("class", "unknown"),
+                "team": det.get("team", ""),
+                "confidence": _round_float(det.get("confidence")),
+                "track_id": det.get("track_id", ""),
+                "bbox_xyxy": det.get("bbox_xyxy", ""),
+                "ball_memory": det.get("ball_memory", ""),
+            }
+        )
+    return rows
+
+
+def _first_existing_path(paths: list[str]) -> Path | None:
+    for path in paths:
+        candidate = Path(path)
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _safe_path(value: object) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return Path(value)
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _list_of_dicts(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _list_of_strings(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _count_value(value: object) -> str:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(int(value))
+    return "0"
+
+
+def _confidence_value(value: object) -> str:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"{float(value):.3f}"
+    return "0.000"
+
+
+def _round_float(value: object) -> float | str:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return round(float(value), 4)
+    return ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ SoccerNet>=0.1.62
 python-dotenv>=1.0
 pytorch-lightning>=2.2.4
 faster-coco-eval>=1.6.0
+umap-learn
+trackers

--- a/src/murawa/services/pipeline.py
+++ b/src/murawa/services/pipeline.py
@@ -231,6 +231,7 @@ def _run_analysis_for_run(
             checkpoint_path=checkpoint_path,
             mode="frame",
         )
+        detections, primary_ball_filter = _select_primary_ball_detections(detections)
     except Exception as exc:
         base_payload["status"] = "error"
         base_payload["resolved_input"] = resolved_input
@@ -279,6 +280,7 @@ def _run_analysis_for_run(
         "debug_preview_assets": debug_preview_assets,
         "stats": stats,
         "team_assignment": team_assignment,
+        "primary_ball_filter": primary_ball_filter,
         "minimap_entities": minimap_entities,
         "detections": detections,
     }
@@ -738,6 +740,42 @@ def _make_base_payload(mode: str, model: str, dataset_variant: str) -> dict:
         "detections": [],
     }
 
+def _select_primary_ball_detections(detections: list[dict]) -> tuple[list[dict], dict]:
+    ball_indexes: list[int] = []
+
+    for idx, detection in enumerate(detections):
+        if normalize_class_name(detection.get("class")) == "ball":
+            ball_indexes.append(idx)
+
+    if len(ball_indexes) <= 1:
+        return detections, {
+            "enabled": True,
+            "policy": "keep_highest_confidence_ball_per_frame",
+            "raw_detection_count": len(detections),
+            "filtered_detection_count": len(detections),
+            "ball_candidates_before": len(ball_indexes),
+            "ball_candidates_after": len(ball_indexes),
+        }
+
+    best_ball_idx = max(
+        ball_indexes,
+        key=lambda idx: float(detections[idx].get("confidence", 0.0)),
+    )
+
+    filtered = [
+        detection
+        for idx, detection in enumerate(detections)
+        if normalize_class_name(detection.get("class")) != "ball" or idx == best_ball_idx
+    ]
+
+    return filtered, {
+        "enabled": True,
+        "policy": "keep_highest_confidence_ball_per_frame",
+        "raw_detection_count": len(detections),
+        "filtered_detection_count": len(filtered),
+        "ball_candidates_before": len(ball_indexes),
+        "ball_candidates_after": 1,
+    }
 
 def _build_detection_stats(detections: list[dict]) -> dict:
     by_class: dict[str, int] = {}

--- a/src/murawa/vision/tracking.py
+++ b/src/murawa/vision/tracking.py
@@ -17,6 +17,7 @@ _TRACK_MATCH_MIN_IOU = 0.05
 _BALL_CLASSES = {"ball"}
 _TEAM_LABELS = {"team_a", "team_b"}
 
+
 DetectionBatch = list[dict[str, Any]]
 TrackingProgressCallback = Callable[[int, int], None]
 
@@ -66,20 +67,34 @@ def smooth_tracked_batches(
     frame_batches: list[DetectionBatch],
     *,
     window_seconds: float = TRACK_SMOOTHING_WINDOW_SECONDS,
+    position_alpha: float = 0.65,
 ) -> list[DetectionBatch]:
-    """Smooth class and player-team labels using recent observations of each track."""
+    """Smooth class/team labels and bbox positions using tracking information.
+
+    Team labels are stabilized offline using all sampled frames from the clip.
+    This reduces team flickering and avoids locking a wrong early label.
+    """
     if window_seconds <= 0:
         raise ValueError("Tracking smoothing window must be positive.")
+    if not 0.0 < position_alpha <= 1.0:
+        raise ValueError("Position smoothing alpha must be in (0, 1].")
+
+    global_team_by_track, global_team_confidence_by_track = _global_team_votes_by_track(
+        frame_batches
+    )
 
     history: dict[int, deque[_TrackObservation]] = defaultdict(deque)
+    previous_bbox_by_track: dict[int, np.ndarray] = {}
     smoothed_batches: list[DetectionBatch] = []
 
     for batch in frame_batches:
         smoothed_batch: DetectionBatch = []
+
         for detection in batch:
             enriched = dict(detection)
             track_id = _read_track_id(enriched.get("track_id"))
             timestamp_seconds = _read_timestamp(enriched.get("timestamp_seconds"))
+
             if track_id is None or timestamp_seconds is None:
                 smoothed_batch.append(enriched)
                 continue
@@ -90,11 +105,14 @@ def smooth_tracked_batches(
                 timestamp_seconds=timestamp_seconds,
                 window_seconds=window_seconds,
             )
+
+            raw_team = _read_team_label(enriched.get("team"))
+
             observations.append(
                 _TrackObservation(
                     timestamp_seconds=timestamp_seconds,
                     class_name=str(enriched.get("class", "")),
-                    team=_read_team_label(enriched.get("team")),
+                    team=raw_team,
                 )
             )
 
@@ -106,20 +124,56 @@ def smooth_tracked_batches(
             if final_class is not None:
                 enriched["class"] = final_class
 
-            team_votes = [
-                observation.team
-                for observation in observations
-                if observation.team in _TEAM_LABELS
-            ]
-            final_team = _strict_majority(team_votes)
-            if final_team is not None:
-                enriched["team"] = final_team
+            # Offline team stabilization:
+            # use all team votes for this track from the whole clip.
+            global_team = global_team_by_track.get(track_id)
+            if global_team is not None:
+                enriched["team_raw"] = raw_team
+                enriched["team"] = global_team
+                enriched["team_smoothed"] = True
+                enriched["team_smoothing"] = "global_track_majority"
                 enriched["team_confidence"] = round(
-                    team_votes.count(final_team) / len(team_votes),
+                    global_team_confidence_by_track.get(track_id, 0.0),
                     4,
                 )
+            else:
+                # Fallback for very short/weak tracks.
+                team_votes = [
+                    observation.team
+                    for observation in observations
+                    if observation.team in _TEAM_LABELS
+                ]
+                final_team = _strict_majority(team_votes)
+                if final_team is not None:
+                    enriched["team_raw"] = raw_team
+                    enriched["team"] = final_team
+                    enriched["team_smoothed"] = True
+                    enriched["team_smoothing"] = "local_window_majority"
+                    enriched["team_confidence"] = round(
+                        team_votes.count(final_team) / len(team_votes),
+                        4,
+                    )
+
+            bbox = read_bbox_xyxy(enriched)
+            if bbox is not None:
+                current_bbox = np.asarray(bbox, dtype=np.float32)
+                previous_bbox = previous_bbox_by_track.get(track_id)
+
+                if previous_bbox is not None:
+                    smoothed_bbox = (
+                        position_alpha * current_bbox
+                        + (1.0 - position_alpha) * previous_bbox
+                    )
+                    enriched["bbox_xyxy"] = [
+                        int(round(float(value))) for value in smoothed_bbox.tolist()
+                    ]
+                    enriched["bbox_smoothed"] = True
+                    previous_bbox_by_track[track_id] = smoothed_bbox
+                else:
+                    previous_bbox_by_track[track_id] = current_bbox
 
             smoothed_batch.append(enriched)
+
         smoothed_batches.append(smoothed_batch)
 
     return smoothed_batches
@@ -130,12 +184,17 @@ def select_primary_ball_batches(
     *,
     memory_seconds: float = PRIMARY_BALL_MEMORY_SECONDS,
 ) -> list[DetectionBatch]:
-    """Keep one rendered ball per frame, preferring the recent selected ball track."""
+    """Keep one rendered ball per frame and reduce short ball flickering.
+
+    If the detector misses the ball for a very short time, reuse the last
+    selected ball position as a temporary memory detection.
+    """
     if memory_seconds < 0:
         raise ValueError("Primary ball memory window must be non-negative.")
 
     selected_track_id: int | None = None
     selected_timestamp: float | None = None
+    selected_ball_detection: dict[str, Any] | None = None
     selected_batches: list[DetectionBatch] = []
 
     for batch in frame_batches:
@@ -144,22 +203,31 @@ def select_primary_ball_batches(
             if _is_ball_detection(detection):
                 ball_candidates.append((detection_index, detection))
 
-        if len(ball_candidates) <= 1:
-            selected_batches.append([dict(detection) for detection in batch])
-            if ball_candidates:
-                selected_track_id, selected_timestamp = _remember_selected_ball(
-                    detection=ball_candidates[0][1],
-                    fallback_track_id=selected_track_id,
-                    fallback_timestamp=selected_timestamp,
-                )
+        batch_timestamp = _batch_timestamp_seconds(batch)
+
+        if not ball_candidates:
+            memory_ball = _make_memory_ball_detection(
+                selected_ball_detection=selected_ball_detection,
+                selected_timestamp=selected_timestamp,
+                current_timestamp=batch_timestamp,
+                memory_seconds=memory_seconds,
+            )
+            if memory_ball is not None:
+                selected_batches.append([dict(detection) for detection in batch] + [memory_ball])
+            else:
+                selected_batches.append([dict(detection) for detection in batch])
             continue
 
-        selected_index, selected_detection = _select_primary_ball_candidate(
-            ball_candidates=ball_candidates,
-            selected_track_id=selected_track_id,
-            selected_timestamp=selected_timestamp,
-            memory_seconds=memory_seconds,
-        )
+        if len(ball_candidates) == 1:
+            selected_index, selected_detection = ball_candidates[0]
+        else:
+            selected_index, selected_detection = _select_primary_ball_candidate(
+                ball_candidates=ball_candidates,
+                selected_track_id=selected_track_id,
+                selected_timestamp=selected_timestamp,
+                memory_seconds=memory_seconds,
+            )
+
         selected_batches.append(
             [
                 dict(detection)
@@ -167,11 +235,13 @@ def select_primary_ball_batches(
                 if not _is_ball_detection(detection) or detection_index == selected_index
             ]
         )
+
         selected_track_id, selected_timestamp = _remember_selected_ball(
             detection=selected_detection,
             fallback_track_id=selected_track_id,
             fallback_timestamp=selected_timestamp,
         )
+        selected_ball_detection = dict(selected_detection)
 
     return selected_batches
 
@@ -409,6 +479,41 @@ def _remember_selected_ball(
         return fallback_track_id, fallback_timestamp
     return track_id, timestamp
 
+def _batch_timestamp_seconds(batch: DetectionBatch) -> float | None:
+    for detection in batch:
+        timestamp = _read_timestamp(detection.get("timestamp_seconds"))
+        if timestamp is not None:
+            return timestamp
+    return None
+
+
+def _make_memory_ball_detection(
+    *,
+    selected_ball_detection: dict[str, Any] | None,
+    selected_timestamp: float | None,
+    current_timestamp: float | None,
+    memory_seconds: float,
+) -> dict[str, Any] | None:
+    if (
+        selected_ball_detection is None
+        or selected_timestamp is None
+        or current_timestamp is None
+    ):
+        return None
+
+    elapsed = current_timestamp - selected_timestamp
+    if elapsed < 0 or elapsed > memory_seconds:
+        return None
+
+    memory_ball = dict(selected_ball_detection)
+    memory_ball["timestamp_seconds"] = round(current_timestamp, 4)
+    memory_ball["ball_memory"] = True
+    memory_ball["ball_memory_age_seconds"] = round(float(elapsed), 4)
+
+    confidence = _read_confidence(memory_ball.get("confidence"))
+    memory_ball["confidence"] = round(max(0.01, confidence * 0.65), 4)
+
+    return memory_ball
 
 def _is_ball_detection(detection: dict[str, Any]) -> bool:
     return normalize_class_name(detection.get("class")) in _BALL_CLASSES
@@ -424,6 +529,54 @@ def _discard_stale_observations(
     while observations and observations[0].timestamp_seconds < cutoff:
         observations.popleft()
 
+def _global_team_votes_by_track(
+    frame_batches: list[DetectionBatch],
+    *,
+    min_observations: int = 2,
+    min_winner_share: float = 0.55,
+) -> tuple[dict[int, str], dict[int, float]]:
+    """Choose one stable team label per track using all sampled frames.
+
+    This is intentionally offline: the whole clip is already processed,
+    so later frames can fix an incorrect early team assignment.
+    """
+    votes_by_track: dict[int, Counter[str]] = defaultdict(Counter)
+    observations_by_track: dict[int, int] = defaultdict(int)
+
+    for batch in frame_batches:
+        for detection in batch:
+            track_id = _read_track_id(detection.get("track_id"))
+            team = _read_team_label(detection.get("team"))
+
+            if track_id is None or team not in _TEAM_LABELS:
+                continue
+
+            weight = _read_confidence(detection.get("team_confidence"))
+            weight = max(0.10, min(1.0, weight))
+
+            votes_by_track[track_id][team] += weight
+            observations_by_track[track_id] += 1
+
+    final_team_by_track: dict[int, str] = {}
+    confidence_by_track: dict[int, float] = {}
+
+    for track_id, votes in votes_by_track.items():
+        if observations_by_track[track_id] < min_observations:
+            continue
+
+        winner, winner_score = votes.most_common(1)[0]
+        total_score = sum(votes.values())
+        if total_score <= 0:
+            continue
+
+        winner_share = winner_score / total_score
+        if winner_share < min_winner_share:
+            continue
+
+        final_team_by_track[track_id] = winner
+        confidence_by_track[track_id] = float(winner_share)
+
+    return final_team_by_track, confidence_by_track
 
 def _strict_majority(values: Iterable[str | None]) -> str | None:
     cleaned = [value for value in values if isinstance(value, str) and value]


### PR DESCRIPTION
## Cel PR

Ten PR realizuje issue #20 i dopracowuje warstwę prezentacyjną aplikacji Streamlit dla analizy pojedynczej klatki oraz analizy klipu meczowego.

Głównym celem było uporządkowanie widoku wyników tak, żeby użytkownik nie musiał od razu analizować surowego JSON-a, tylko mógł szybko zobaczyć podgląd wejścia, wynik predykcji, statystyki, przypisanie drużyn oraz dane przygotowane pod minimapę.

---

## Zakres zmian

W ramach PR dodano / poprawiono:

- czytelniejszy widok analizy pojedynczej klatki,
- metryki podsumowujące wynik analizy,
- podgląd wejścia i wyniku obok siebie,
- zakładki z uporządkowanymi wynikami:
  - `Podsumowanie`,
  - `Drużyny`,
  - `Minimapa`,
  - `Raw JSON`,
- tabelę klas detekcji,
- tabelę detekcji z klasą, drużyną, confidence, track_id i bboxem,
- tabelę podsumowania drużyn,
- tabelę kolorów drużyn,
- wizualizację cech kolorów koszulek z użyciem UMAP,
- fallback PCA, gdy UMAP nie jest dostępny,
- tabelę `minimap_entities`,
- ukrycie surowego wyniku JSON w osobnej zakładce,
- filtrowanie detekcji piłki do jednej piłki z najwyższym confidence dla analizy klatki,
- poprawione etykiety i raw summary w widoku analizy meczu,
- stabilizację etykiet drużyn w klipie po `track_id`,
- wygładzanie pozycji bboxów po trackingu,
- krótką pamięć ostatniej pozycji piłki, aby ograniczyć miganie piłki w wynikowym wideo.

---

## Widok analizy pojedynczej klatki

Widok analizy klatki został uporządkowany tak, żeby był bardziej spójny z widokiem analizy meczu.

Po analizie widoczne są metryki:

- liczba detekcji,
- liczba klas,
- średni confidence,
- liczba wykrytych drużyn / ról,
- liczba `minimap_entities`.

Dodatkowo widok pokazuje obok siebie:

- klatkę wejściową,
- wynik analizy z naniesionymi detekcjami i przypisaniem drużyn.

Surowy JSON nie jest już głównym widokiem wyniku — został przeniesiony do osobnej zakładki `Raw JSON`.

---
## Filtrowanie piłki

Dla analizy pojedynczej klatki dodano prosty mechanizm wyboru jednej piłki.

Jeżeli model zwróci kilka kandydatów klasy `ball`, pipeline zostawia tylko detekcję z najwyższym `confidence`.

Do wyniku dopisywane jest także podsumowanie w polu `primary_ball_filter`, które zawiera między innymi:

- `enabled` — informację, czy filtr jest aktywny,
- `policy` — zastosowaną strategię filtrowania,
- `raw_detection_count` — liczbę detekcji przed filtrowaniem,
- `filtered_detection_count` — liczbę detekcji po filtrowaniu,
- `ball_candidates_before` — liczbę kandydatów piłki przed filtrowaniem,
- `ball_candidates_after` — liczbę kandydatów piłki po filtrowaniu.

Dzięki temu wynik klatki nie powinien zawierać kilku konkurencyjnych detekcji piłki.

## Wizualizacja UMAP

W zakładce 'Drużyny' dodano pomocniczą wizualizację cech kolorów koszulek.
Dla zawodników z przypisanym kolorem koszulki budowane są proste cechy koloru, a następnie wyświetlana jest projekcja 2D:
-UMAP, jeżeli umap-learn jest dostępny,
-fallback PCA, jeżeli UMAP nie jest dostępny.
Ta wizualizacja nie zastępuje logiki przypisywania drużyn. Służy jako narzędzie diagnostyczne, które pomaga ocenić, czy zawodnicy tworzą sensowne grupy w przestrzeni cech.

## Dane pod minimapę

Wynik analizy pokazuje teraz osobną zakładkę 'Minimapa'.

Dane 'minimap_entities' są prezentowane w tabeli z polami:
-class,
-team,
-center_xy,
-bbox_xyxy,
-confidence,
-track_id,
-frame_index.
Dzięki temu łatwiej sprawdzić, jakie dane będą przekazywane do przyszłego modułu minimapy.

## Stabilizacja wideo

W analizie klipu dodano dodatkowe wygładzanie po trackingu.
Poprawki obejmują:
-stabilizację etykiet drużyn po track_id,
-globalne głosowanie po całym tracku w klipie,
-ograniczenie sytuacji, w której zawodnik przeskakuje między team_a i team_b (CO JEDNAK NIE DZIAŁA NAJPRAWDOPODOBNIEJ :( )
-wygładzanie pozycji bboxów między klatkami,
-krótką pamięć ostatniej pozycji piłki, gdy piłka znika na pojedynczych próbkowanych klatkach.
Ważne: ta stabilizacja działa w zakresie możliwym bez implementowania nowego trackingu. Pełny tracking pozostaje osobnym elementem projektu.

## Ograniczenia

To nadal jest warstwa prezentacyjna i lekki postprocessing, nie nowy model detekcyjny ani pełny system trackingowy.
Możliwe ograniczenia:
-team assignment nadal zależy od jakości cropów koszulek,
-przy słabych detekcjach lub krótkich trackach etykiety mogą być mniej stabilne,
-jeżeli ByteTrack nada temu samemu zawodnikowi nowy track_id, głosowanie po tracku nie sklei automatycznie tych fragmentów,
-UMAP jest wizualizacją pomocniczą, nie mechanizmem decyzyjnym.

## Testy
Wykonano test analizy pojedynczej klatki na przykładzie meczu Barca–Atleti.

Sprawdzono:
-metryki analizy,
-podgląd wejścia i wyniku,
-podsumowanie klas,
-podsumowanie drużyn,
-wizualizację UMAP,
-tabelę minimap_entities,
-widok Raw JSON.

## Opis najważniejszych zmian w kodzie

Zmiany zostały podzielone na część prezentacyjną Streamlit oraz lekki postprocessing wyników analizy.

### `app/ui_common.py`

Dodano bardziej uporządkowaną prezentację wyniku analizy pojedynczej klatki.

Najważniejsze elementy:

- `show_result(...)` rozpoznaje teraz tryb analizy i dla pojedynczej klatki pokazuje dedykowany widok zamiast od razu wyświetlać cały JSON.
- `_show_frame_result(...)` buduje główny widok wyniku klatki: metryki, podgląd wejścia i wyniku oraz zakładki z dodatkowymi informacjami.
- `_show_frame_metrics(...)` pokazuje najważniejsze liczby: detekcje, klasy, średni confidence, drużyny/role i `minimap_entities`.
- `_show_frame_previews(...)` pokazuje obok siebie obraz wejściowy i obraz wynikowy z detekcjami.
- `_show_team_feature_scatter(...)` tworzy pomocniczą wizualizację 2D cech kolorów koszulek.
- `_project_2d(...)` używa UMAP, jeśli biblioteka `umap-learn` jest dostępna, a w przeciwnym razie korzysta z fallbacku PCA.
- `_show_minimap_entities(...)` prezentuje dane przygotowane pod przyszły moduł minimapy w czytelnej tabeli.

Dzięki temu widok analizy klatki jest bardziej podobny do widoku analizy meczu i nie wymaga ręcznego czytania całego surowego JSON-a.

### `app/pages/frame_page.py`

Do `show_result(...)` przekazywany jest teraz obraz wejściowy z uploadu.

Pozwala to pokazać w Streamlit dwa obrazy obok siebie:

- oryginalną klatkę,
- wynik analizy z detekcjami i przypisaniem drużyn.

### `app/pages/match_page.py`

Widok analizy meczu został lekko uporządkowany:

- zmieniono opis przycisku pobierania na bardziej jednoznaczny,
- dodano `Raw summary` w expanderze, żeby techniczne dane były dostępne, ale nie zaśmiecały głównego widoku.

### `src/murawa/services/pipeline.py`

Dodano prosty filtr detekcji piłki dla analizy pojedynczej klatki.

Funkcja `_select_primary_ball_detections(...)` sprawdza, czy model zwrócił więcej niż jedną detekcję klasy `ball`. Jeżeli tak, zostawia tylko kandydatkę z najwyższym `confidence`.

Do wyniku dopisywane jest pole `primary_ball_filter`, które opisuje, ile detekcji było przed i po filtrowaniu.

### `src/murawa/vision/tracking.py`

Rozszerzono postprocessing wyników trackingowych dla analizy wideo.

Najważniejsze zmiany:

- `smooth_tracked_batches(...)` stabilizuje etykiety drużyn po `track_id`.
- Dla drużyn zastosowano globalne głosowanie po całym tracku, czyli cały klip może zostać użyty do wybrania najbardziej prawdopodobnej etykiety dla danego zawodnika.
- Dzięki temu ograniczamy sytuacje, w których zawodnik przez kilka klatek przeskakuje między `team_a` i `team_b`.
- Dodano także wygładzanie pozycji bboxów między klatkami, żeby zmniejszyć drganie ramek.
- `select_primary_ball_batches(...)` ogranicza wynik do jednej głównej piłki na klatkę i dodaje krótką pamięć ostatniej pozycji piłki, gdy detekcja chwilowo zniknie.

Ta część nie zastępuje trackingu ani modelu detekcyjnego, tylko poprawia stabilność prezentacji wyniku wideo.

## KLATKA - SCREENY
<img width="1566" height="872" alt="image" src="https://github.com/user-attachments/assets/0ccf7f79-7758-45eb-ba02-7e9e82258fb2" />
<img width="1557" height="832" alt="image" src="https://github.com/user-attachments/assets/5d121261-0796-49db-8f61-6269162b680f" />
<img width="1542" height="861" alt="image" src="https://github.com/user-attachments/assets/4f82f858-1ce5-4d46-b0ff-a51a8c52438e" />
<img width="1600" height="707" alt="image" src="https://github.com/user-attachments/assets/e6ec3518-81f2-4b42-a352-dd66ae758903" />
<img width="1199" height="715" alt="image" src="https://github.com/user-attachments/assets/08951b7d-8be8-4069-aa38-f74f9532ad23" />


## KLIP WIDEO
<img width="1673" height="869" alt="image" src="https://github.com/user-attachments/assets/5ecfd381-c7d6-443e-9c7a-9b351108e0c6" />
<img width="1683" height="878" alt="image" src="https://github.com/user-attachments/assets/275deaee-e5b3-4596-a7ae-1c95205df2b1" />

### do wglądu wideo
(10fps, ramki detekcji ON)
https://drive.google.com/drive/folders/1SztT91zbkaCQ56D9LXJ35I6QD-FxZWnQ?usp=sharing



